### PR TITLE
Remove active border rendering from terminal pane

### DIFF
--- a/crates/kazeterm/src/components/split_pane.rs
+++ b/crates/kazeterm/src/components/split_pane.rs
@@ -200,19 +200,8 @@ impl SplitPane {
   ) -> AnyElement {
     match self {
       SplitPane::Terminal { id, terminal } => {
-        let is_active = Some(*id) == active_pane_id;
-        let border_color = if is_active {
-          let setting_store = cx.global::<themeing::SettingsStore>();
-          let theme = setting_store.theme();
-          theme.colors().border_focused
-        } else {
-          gpui::transparent_black()
-        };
-
         div()
           .size_full()
-          .border_2()
-          .border_color(border_color)
           .child(terminal.clone())
           .into_any_element()
       }


### PR DESCRIPTION
This pull request simplifies the rendering logic for the `SplitPane::Terminal` component by removing the visual indication of the active pane. Specifically, it eliminates the conditional border styling that highlighted the active terminal pane.

UI simplification:

* Removed the logic that set a distinct border color for the active terminal pane, as well as the associated border rendering, from the `SplitPane::Terminal` rendering method in `split_pane.rs`.