### PR TITLE
Add SSH host retrieval and enhance terminal profile handling

### DIFF
--- a/crates/config/src/shell.rs
+++ b/crates/config/src/shell.rs
@@ -236,7 +236,7 @@ fn get_shell_candidates() -> Vec<ShellCandidate> {
 /// Detect Linux containers (Docker, Podman, distrobox) that can be used as shell environments.
 /// This works on Linux and macOS where container runtimes are commonly available.
 #[cfg(unix)]
-fn detect_container_shells() -> Vec<DetectedShell> {
+pub fn detect_container_shells() -> Vec<DetectedShell> {
   let mut shells = Vec::new();
 
   // Detect Docker containers
@@ -250,7 +250,7 @@ fn detect_container_shells() -> Vec<DetectedShell> {
         let container = container.trim();
         if !container.is_empty() {
           shells.push(DetectedShell {
-            name: format!("Docker: {}", container),
+            name: format!("[Docker] {}", container),
             command: format!("docker exec -it {} /bin/sh", container),
           });
         }
@@ -269,7 +269,7 @@ fn detect_container_shells() -> Vec<DetectedShell> {
         let container = container.trim();
         if !container.is_empty() {
           shells.push(DetectedShell {
-            name: format!("Podman: {}", container),
+            name: format!("[Podman] {}", container),
             command: format!("podman exec -it {} /bin/sh", container),
           });
         }
@@ -292,7 +292,7 @@ fn detect_container_shells() -> Vec<DetectedShell> {
           let container_name = parts[1].trim();
           if !container_name.is_empty() && container_name != "NAME" {
             shells.push(DetectedShell {
-              name: format!("Distrobox: {}", container_name),
+              name: format!("[Distrobox] {}", container_name),
               command: format!("distrobox enter {}", container_name),
             });
           }
@@ -306,7 +306,7 @@ fn detect_container_shells() -> Vec<DetectedShell> {
 
 /// Detect Linux containers on Windows (via Docker Desktop or WSL).
 #[cfg(target_os = "windows")]
-fn detect_container_shells() -> Vec<DetectedShell> {
+pub fn detect_container_shells() -> Vec<DetectedShell> {
   let mut shells = Vec::new();
 
   // Detect Docker containers (Docker Desktop on Windows)
@@ -320,7 +320,7 @@ fn detect_container_shells() -> Vec<DetectedShell> {
         let container = container.trim();
         if !container.is_empty() {
           shells.push(DetectedShell {
-            name: format!("Docker: {}", container),
+            name: format!("[Docker] {}", container),
             command: format!("docker exec -it {} /bin/sh", container),
           });
         }
@@ -339,7 +339,7 @@ fn detect_container_shells() -> Vec<DetectedShell> {
         let container = container.trim();
         if !container.is_empty() {
           shells.push(DetectedShell {
-            name: format!("Podman: {}", container),
+            name: format!("[Podman] {}", container),
             command: format!("podman exec -it {} /bin/sh", container),
           });
         }
@@ -406,7 +406,7 @@ pub fn detect_shells() -> Vec<DetectedShell> {
   }
 
   // Add container shells (Docker, Podman, distrobox)
-  detected.extend(detect_container_shells());
+  // detected.extend(detect_container_shells());
 
   detected
 }

--- a/crates/config/src/ssh.rs
+++ b/crates/config/src/ssh.rs
@@ -1,0 +1,34 @@
+use std::io::BufRead;
+
+pub fn get_ssh_hosts() -> Vec<String> {
+    let mut hosts = Vec::new();
+    let ssh_config_path = dirs::home_dir().map(|h| h.join(".ssh/config"));
+
+    if let Some(path) = ssh_config_path {
+        if path.exists() {
+            if let Ok(file) = std::fs::File::open(path) {
+                let reader = std::io::BufReader::new(file);
+                for line in reader.lines() {
+                    if let Ok(line) = line {
+                        let line = line.trim();
+                        // Case insensitive check for "Host "
+                        if line.to_lowercase().starts_with("host ") {
+                            let parts: Vec<&str> = line.split_whitespace().collect();
+                            // parts[0] is "Host" (or "host")
+                            if parts.len() > 1 {
+                                for part in &parts[1..] {
+                                    // Exclude patterns containing wildcards
+                                    if !part.contains('*') && !part.contains('?') && !part.contains('!') {
+                                        hosts.push(part.to_string());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    hosts
+}

--- a/crates/kazeterm/src/components/terminal_window.rs
+++ b/crates/kazeterm/src/components/terminal_window.rs
@@ -9,7 +9,8 @@ use terminal::{PtyProcessInfo, TerminalBounds, TerminalEventListener, TerminalVi
 use crate::components::MainWindow;
 
 fn new_terminal(
-  shell: String,
+  program: String,
+  args: Vec<String>,
   working_directory: Option<PathBuf>,
 ) -> (
   terminal::Terminal,
@@ -37,7 +38,7 @@ fn new_terminal(
   let term = Arc::new(FairMutex::new(term));
 
   let pty_options = {
-    let alac_shell = alacritty_terminal::tty::Shell::new(shell, vec![]);
+    let alac_shell = alacritty_terminal::tty::Shell::new(program, args);
 
     alacritty_terminal::tty::Options {
       shell: Some(alac_shell),
@@ -73,11 +74,12 @@ fn new_terminal(
 pub fn new_terminal_window_with_shell(
   window: &mut gpui::Window,
   index: usize,
-  shell: &str,
+  program: &str,
+  args: Vec<String>,
   working_directory: Option<PathBuf>,
   cx: &mut Context<MainWindow>,
 ) -> Entity<TerminalView> {
-  let (terminal, events_rx) = new_terminal(shell.to_string(), working_directory);
+  let (terminal, events_rx) = new_terminal(program.to_string(), args, working_directory);
   let mut events_rx = events_rx;
   let terminal = cx.new(|_| terminal);
   let weak_terminal = terminal.downgrade();


### PR DESCRIPTION
- Implement `get_ssh_hosts` function to retrieve SSH hosts from the user's SSH config.
- Modify profile handling in `MainWindow` to support SSH profiles.
- Update terminal creation to accept shell arguments.
- Refactor container shell detection to improve clarity and functionality.