### PR TITLE
Fix cannot drag the scroll bar

### DIFF
--- a/crates/terminal/src/scrollbar.rs
+++ b/crates/terminal/src/scrollbar.rs
@@ -4,7 +4,7 @@ use gpui::{BorderStyle, Bounds, Hsla, Pixels, Point, Window, fill, px};
 pub const SCROLLBAR_WIDTH: f32 = 12.0;
 
 /// Minimum thumb height in pixels
-const MIN_THUMB_HEIGHT: f32 = 20.0;
+pub const MIN_THUMB_HEIGHT: f32 = 20.0;
 
 /// Scrollbar state for rendering
 #[derive(Clone, Debug)]
@@ -74,6 +74,64 @@ impl ScrollbarState {
     // Invert the position (top = history_size, bottom = 0)
     let inverted = 1.0 - position_ratio;
     (inverted * self.history_size as f32).round() as usize
+  }
+
+  /// Convert a thumb top position (0.0 to 1.0) to a scroll offset
+  /// This accounts for the thumb size when mapping position to offset
+  pub fn thumb_top_to_offset(&self, thumb_top_ratio: f32) -> usize {
+    if self.history_size == 0 {
+      return 0;
+    }
+
+    let (_, thumb_size) = self.thumb_metrics();
+    let max_thumb_top = 1.0 - thumb_size;
+
+    if max_thumb_top <= 0.0 {
+      return 0;
+    }
+
+    // Normalize thumb position to 0-1 range within the scrollable area
+    let normalized = (thumb_top_ratio / max_thumb_top).clamp(0.0, 1.0);
+    // Invert: thumb at top (0) = max offset, thumb at bottom (1) = 0 offset
+    let offset = (1.0 - normalized) * self.history_size as f32;
+    offset.round() as usize
+  }
+
+  /// Get the actual thumb position and height in pixels, accounting for MIN_THUMB_HEIGHT
+  /// Returns (thumb_top_px, thumb_height_px, effective_track_height)
+  pub fn thumb_pixel_bounds(&self, track_height: Pixels) -> (Pixels, Pixels) {
+    let (thumb_top_ratio, thumb_size_ratio) = self.thumb_metrics();
+
+    // Calculate actual thumb height with minimum
+    let thumb_height = (track_height * thumb_size_ratio).max(px(MIN_THUMB_HEIGHT));
+    let thumb_top = track_height * thumb_top_ratio;
+    // Adjust thumb position if it would overflow
+    let thumb_top = thumb_top.min(track_height - thumb_height);
+
+    (thumb_top, thumb_height)
+  }
+
+  /// Convert a pixel Y position within the track to a scroll offset
+  /// This uses the actual visual thumb position accounting for MIN_THUMB_HEIGHT
+  pub fn pixel_to_offset(&self, y_px: Pixels, track_height: Pixels) -> usize {
+    if self.history_size == 0 {
+      return 0;
+    }
+
+    let (_, thumb_height) = self.thumb_pixel_bounds(track_height);
+    let scrollable_height = track_height - thumb_height;
+
+    if scrollable_height <= px(0.0) {
+      return 0;
+    }
+
+    // Clamp y to valid range
+    let thumb_top = y_px.clamp(px(0.0), scrollable_height);
+    let normalized: f32 = (thumb_top / scrollable_height).into();
+
+    // Invert: top = max offset, bottom = 0
+    let offset = (1.0 - normalized) * self.history_size as f32;
+    offset as usize
   }
 
   /// Check if a position ratio (0.0 to 1.0) is within the thumb area

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -59,6 +59,8 @@ pub struct TerminalView {
   pub scroll_top: Pixels,
   // scroll_handle: TerminalScrollHandle,
   pub ime_state: Option<ImeState>,
+  /// Scrollbar drag state: stores the initial offset when drag started
+  pub scrollbar_drag_offset: Option<f32>,
   _subscriptions: Vec<gpui::Subscription>,
   _terminal_subscriptions: Vec<gpui::Subscription>,
 }
@@ -144,6 +146,7 @@ impl TerminalView {
       hover_tooltip_update: Task::ready(()),
       scroll_top: Pixels::ZERO,
       ime_state: None,
+      scrollbar_drag_offset: None,
       index: index,
       _subscriptions: vec![focus_in, focus_out],
       _terminal_subscriptions: terminal_subscriptions,

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -59,8 +59,8 @@ pub struct TerminalView {
   pub scroll_top: Pixels,
   // scroll_handle: TerminalScrollHandle,
   pub ime_state: Option<ImeState>,
-  /// Scrollbar drag state: stores the initial offset when drag started
-  pub scrollbar_drag_offset: Option<f32>,
+  /// Scrollbar drag state: stores (offset from thumb top to click, last mouse Y in pixels)
+  pub scrollbar_drag_state: Option<(f32, f32)>,
   _subscriptions: Vec<gpui::Subscription>,
   _terminal_subscriptions: Vec<gpui::Subscription>,
 }
@@ -146,7 +146,7 @@ impl TerminalView {
       hover_tooltip_update: Task::ready(()),
       scroll_top: Pixels::ZERO,
       ime_state: None,
-      scrollbar_drag_offset: None,
+      scrollbar_drag_state: None,
       index: index,
       _subscriptions: vec![focus_in, focus_out],
       _terminal_subscriptions: terminal_subscriptions,


### PR DESCRIPTION
This pull request adds support for interactive scrollbar dragging in the terminal UI, improving the user experience when scrolling through terminal history. The main changes involve new methods for precise scrollbar interaction, updated event handling for mouse actions, and state management for drag operations.

**Scrollbar interaction improvements:**

* Added several new methods to `ScrollbarState` in `scrollbar.rs` for converting between thumb position, pixel position, and scroll offset, as well as detecting if a mouse event is on the thumb (`thumb_top_to_offset`, `thumb_pixel_bounds`, `pixel_to_offset`, `is_on_thumb`).
* Made `MIN_THUMB_HEIGHT` a public constant for consistent use across modules.

**Terminal UI event handling:**

* Updated `TerminalElement` in `terminal_element.rs` to handle mouse events for scrollbar dragging, including:
  - Ignoring terminal mouse events when clicking on the scrollbar.
  - Handling mouse down to initiate drag or jump to position.
  - Handling mouse move to update scroll position during drag, with minimum movement threshold.
  - Handling mouse up to end dragging. [[1]](diffhunk://#diff-31bb91b6f48af18b299aed5abd41c76fbb4e97414a0ea2ca232514ec487d3ebeL974-R1095) [[2]](diffhunk://#diff-31bb91b6f48af18b299aed5abd41c76fbb4e97414a0ea2ca232514ec487d3ebeR348-R354) [[3]](diffhunk://#diff-31bb91b6f48af18b299aed5abd41c76fbb4e97414a0ea2ca232514ec487d3ebeL862-R870) [[4]](diffhunk://#diff-31bb91b6f48af18b299aed5abd41c76fbb4e97414a0ea2ca232514ec487d3ebeR335)

**State management:**

* Added a new `scrollbar_drag_state` field to `TerminalView` to track the drag operation state and updated its initialization. [[1]](diffhunk://#diff-b82937ebfb48e435732c1b8552686b61d06a1f0e4696714418ea4fe8d40d41d0R62-R63) [[2]](diffhunk://#diff-b82937ebfb48e435732c1b8552686b61d06a1f0e4696714418ea4fe8d40d41d0R149)

**Testing:**

* Added unit tests for the new `is_on_thumb` method to ensure correct detection of thumb interactions.

**Other:**

* Updated imports in `terminal_element.rs` to include the now-public `MIN_THUMB_HEIGHT`.


#35 