### PR TITLE
Update input cursor appearance in tab rename dialog and set caret color in theme

### DIFF
--- a/crates/kazeterm/src/components/tab_rename_dialog.rs
+++ b/crates/kazeterm/src/components/tab_rename_dialog.rs
@@ -142,7 +142,7 @@ impl Render for TabRenameDialog {
               .child(
                 div()
                   .w_full()
-                  .child(Input::new(&self.input_state).w_full().appearance(false)),
+                  .child(Input::new(&self.input_state).w_full().cursor_text()),
               )
               .child(
                 div()

--- a/crates/themeing/src/lib.rs
+++ b/crates/themeing/src/lib.rs
@@ -267,6 +267,9 @@ impl SettingsStore {
       theme.muted = colors.text_muted;
       theme.muted_foreground = colors.text_muted;
 
+      // Caret color (same as text for consistency)
+      theme.caret = colors.text;
+
       // Popup/dropdown menu styling
       theme.popover = colors.elevated_surface_background;
       theme.popover_foreground = colors.text;


### PR DESCRIPTION
This pull request introduces a minor UI improvement and a theming enhancement to the application. The most important changes are:

UI Improvement:

* Changed the `TabRenameDialog` input field to use a text cursor style for better user experience, replacing the previous appearance setting. (`crates/kazeterm/src/components/tab_rename_dialog.rs`)

Theming Enhancement:

* Added a caret color to the theme that matches the text color, ensuring caret visibility and consistency across the application. (`crates/themeing/src/lib.rs`)

#30 