### PR TITLE
Vertical tabs

### DIFF
--- a/assets/icons/arrow-down.svg
+++ b/assets/icons/arrow-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-move-down-icon lucide-move-down"><path d="M8 18L12 22L16 18"/><path d="M12 2V22"/></svg>

--- a/assets/icons/arrow-up.svg
+++ b/assets/icons/arrow-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-move-up-icon lucide-move-up"><path d="M8 6L12 2L16 6"/><path d="M12 2V22"/></svg>

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -34,7 +34,7 @@ pub struct Profile {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
-  /// Config file version in YYYYMMDD.Rev format (e.g., "20260208.1")
+  /// Config file version in YYYYMMDD.Rev format (e.g., "20260220.1")
   pub version: String,
   pub theme: String,
   pub theme_mode: ThemeMode,
@@ -54,6 +54,8 @@ pub struct Config {
   pub container_profiles: Vec<Profile>,
   /// Enable the terminal minimap (shows a zoomed-out preview of scrollback)
   pub minimap_enabled: bool,
+  /// Render tabs vertically in a left sidebar instead of horizontally at the top
+  pub vertical_tabs: bool,
   /// Close the application when the last tab is closed
   /// When false (default), a new tab is created instead
   pub close_on_last_tab: bool,
@@ -79,6 +81,7 @@ impl Default for Config {
       window_height: 600.0,
       container_profiles: detect_container_profiles(),
       minimap_enabled: false,
+      vertical_tabs: false,
       close_on_last_tab: true,
     }
   }
@@ -428,6 +431,7 @@ mod tests {
       window_height: 50.0,
       container_profiles: vec![],
       minimap_enabled: false,
+      vertical_tabs: false,
       close_on_last_tab: true,
     };
 

--- a/crates/kazeterm/src/components/main_window_render.rs
+++ b/crates/kazeterm/src/components/main_window_render.rs
@@ -786,6 +786,7 @@ impl Render for MainWindow {
                 .h_full()
                 .flex_shrink_0()
                 .w(px(TAB_LABEL_MAX_WIDTH + 24.0))
+                .bg(colors.title_bar_background)
                 .p_1()
                 .child(
                   TerminalTabBar::new("tabs-vertical")

--- a/crates/kazeterm/src/components/main_window_render.rs
+++ b/crates/kazeterm/src/components/main_window_render.rs
@@ -801,12 +801,16 @@ impl Render for MainWindow {
                           let shell_icon = ShellIcon::new(&item.shell_path);
                           let tab_index = item.index;
                           let tab_title = item.display_title().to_string();
+                          let total_tabs = self.items.len();
+                          let is_first = tab_ix == 0;
+                          let is_last = tab_ix == total_tabs - 1;
                           let is_selected = self.active_tab_ix == Some(tab_ix);
                           let has_bell = item
                             .split_container
                             .all_terminals()
                             .iter()
                             .any(|(_, t)| t.read(cx).has_bell());
+                          let view = cx.entity();
                           let view_for_click = view.clone();
                           let all_terminals = item.split_container.all_terminals();
                           let selected_bg: gpui::Hsla = colors.tab_active_background;
@@ -832,51 +836,251 @@ impl Render for MainWindow {
                               cx.stop_propagation();
                             })
                             .child(
-                              h_flex()
-                                .w_full()
-                                .gap_1p5()
-                                .pl_2p5()
-                                .pr_1()
-                                .py_1()
-                                .items_center()
-                                .min_w(px(TAB_LABEL_MIN_WIDTH))
-                                .max_w(px(TAB_LABEL_MAX_WIDTH))
-                                .when(is_selected, |this| {
-                                  this.bg(selected_bg).border_l_2().border_color(accent_color)
-                                })
-                                .when(!is_selected, |this| {
-                                  this.bg(normal_bg).hover(|style| style.bg(hover_bg))
-                                })
-                                .rounded_md()
+                              div()
+                                .id(ElementId::NamedInteger("tab-container".into(), tab_ix as u64))
+                                .group("tab-item")
                                 .child(
                                   div()
-                                    .flex_shrink_0()
-                                    .child(shell_icon.into_element(px(14.0))),
-                                )
-                                .when(has_bell, |this| {
-                                  this.child(
-                                    div().flex_shrink_0().child(
-                                      Icon::new(IconName::Bell)
-                                        .size_3()
-                                        .text_color(warning_color),
-                                    ),
-                                  )
-                                })
-                                .child(
-                                  div().flex_1().min_w_0().overflow_x_hidden().child(
-                                    Label::new(tab_title.clone())
-                                      .text_color(if is_selected { text_color } else { text_muted })
-                                      .whitespace_nowrap(),
-                                  ),
-                                )
-                                .child(
-                                  TabButton::new("close-vertical", tab_index)
-                                    .visible(true)
-                                    .on_click(cx.listener(
-                                      |this, e: &TabButtonClickEvent, window, cx| {
-                                        this.remove_tab_by(e.index, window, cx);
+                                    .id(ElementId::NamedInteger("tab-drag".into(), tab_ix as u64))
+                                    .cursor(CursorStyle::OpenHand)
+                                    .on_drag(
+                                      DraggedTab {
+                                        from_ix: tab_ix,
+                                        title: tab_title.clone(),
+                                        shell_path: item.shell_path.clone(),
                                       },
-                                    )),
+                                      |dragged: &DraggedTab, _offset, _window, cx| {
+                                        cx.new(|_cx| {
+                                          DraggedTabView::new(
+                                            dragged.title.clone(),
+                                            dragged.shell_path.clone(),
+                                          )
+                                        })
+                                      },
+                                    )
+                                    .drag_over::<DraggedTab>(move |style, _dragged, _window, _cx| {
+                                      style
+                                        .bg(accent_color.opacity(0.15))
+                                        .border_l_2()
+                                        .border_color(accent_color)
+                                    })
+                                    .on_drop(cx.listener(
+                                      move |this, dragged: &DraggedTab, _window, cx| {
+                                        let from_ix = dragged.from_ix;
+                                        let to_ix = tab_ix;
+                                        if from_ix != to_ix {
+                                          let item = this.items.remove(from_ix);
+                                          let insert_ix = if from_ix < to_ix { to_ix } else { to_ix };
+                                          this.items.insert(insert_ix, item);
+                                          if let Some(active) = this.active_tab_ix {
+                                            if active == from_ix {
+                                              this.active_tab_ix = Some(insert_ix);
+                                            } else if from_ix < active && active <= to_ix {
+                                              this.active_tab_ix = Some(active - 1);
+                                            } else if to_ix <= active && active < from_ix {
+                                              this.active_tab_ix = Some(active + 1);
+                                            }
+                                          }
+                                          cx.notify();
+                                        }
+                                      },
+                                    ))
+                                    .child(
+                                      h_flex()
+                                        .w_full()
+                                        .gap_1p5()
+                                        .pl_2p5()
+                                        .pr_1()
+                                        .py_1()
+                                        .items_center()
+                                        .min_w(px(TAB_LABEL_MIN_WIDTH))
+                                        .max_w(px(TAB_LABEL_MAX_WIDTH))
+                                        .when(is_selected, |this| {
+                                          this.bg(selected_bg).border_l_2().border_color(accent_color)
+                                        })
+                                        .when(!is_selected, |this| {
+                                          this.bg(normal_bg).hover(|style| style.bg(hover_bg))
+                                        })
+                                        .rounded_md()
+                                        .child(
+                                          div()
+                                            .flex_shrink_0()
+                                            .child(shell_icon.into_element(px(14.0))),
+                                        )
+                                        .when(has_bell, |this| {
+                                          this.child(
+                                            div().flex_shrink_0().child(
+                                              Icon::new(IconName::Bell)
+                                                .size_3()
+                                                .text_color(warning_color),
+                                            ),
+                                          )
+                                        })
+                                        .child(
+                                          div().flex_1().min_w_0().overflow_x_hidden().child(
+                                            Label::new(tab_title.clone())
+                                              .text_color(if is_selected {
+                                                text_color
+                                              } else {
+                                                text_muted
+                                              })
+                                              .whitespace_nowrap(),
+                                          ),
+                                        )
+                                        .child({
+                                          let close_visible = is_selected;
+                                          div()
+                                            .flex_shrink_0()
+                                            .when(!close_visible, |this| {
+                                              this
+                                                .invisible()
+                                                .group_hover("tab-item", |style| style.visible())
+                                            })
+                                            .child(
+                                              TabButton::new("close-vertical", tab_index)
+                                                .visible(true)
+                                                .on_click(cx.listener(
+                                                  |this, e: &TabButtonClickEvent, window, cx| {
+                                                    this.remove_tab_by(e.index, window, cx);
+                                                  },
+                                                )),
+                                            )
+                                        })
+                                        .on_mouse_down(MouseButton::Right, |_, _, cx| {
+                                          cx.stop_propagation();
+                                        })
+                                        .context_menu({
+                                          let view = view.clone();
+                                          move |menu, _window, _cx| {
+                                            let view_rename = view.clone();
+                                            let view_duplicate = view.clone();
+                                            let view_split_h = view.clone();
+                                            let view_split_v = view.clone();
+                                            let view_close_pane = view.clone();
+                                            let view_move_left = view.clone();
+                                            let view_move_right = view.clone();
+                                            let view_close_others = view.clone();
+                                            let view_close_right = view.clone();
+                                            let view_close_tab = view.clone();
+                                            menu
+                                              .item(
+                                                PopupMenuItem::new("Rename Tab")
+                                                  .icon(Icon::empty().path("icons/pencil.svg"))
+                                                  .on_click(move |_, window, cx| {
+                                                    view_rename.update(cx, |this, cx| {
+                                                      this.show_rename_dialog(tab_index, window, cx);
+                                                    });
+                                                  }),
+                                              )
+                                              .item(
+                                                PopupMenuItem::new("Duplicate Tab")
+                                                  .icon(Icon::empty().path("icons/copy.svg"))
+                                                  .on_click(move |_, window, cx| {
+                                                    view_duplicate.update(cx, |this, cx| {
+                                                      this.duplicate_tab(tab_index, window, cx);
+                                                    });
+                                                  }),
+                                              )
+                                              .separator()
+                                              .item(
+                                                PopupMenuItem::new("Split Horizontal (Ctrl+Shift+D)")
+                                                  .icon(Icon::empty().path("icons/columns-2.svg"))
+                                                  .on_click(move |_, window, cx| {
+                                                    view_split_h.update(cx, |this, cx| {
+                                                      this.split_pane_horizontal(window, cx);
+                                                    });
+                                                  }),
+                                              )
+                                              .item(
+                                                PopupMenuItem::new("Split Vertical (Ctrl+Shift+E)")
+                                                  .icon(Icon::empty().path("icons/rows-2.svg"))
+                                                  .on_click(move |_, window, cx| {
+                                                    view_split_v.update(cx, |this, cx| {
+                                                      this.split_pane_vertical(window, cx);
+                                                    });
+                                                  }),
+                                              )
+                                              .item(
+                                                PopupMenuItem::new("Close Pane (Ctrl+Shift+W)")
+                                                  .icon(IconName::Close)
+                                                  .on_click(move |_, window, cx| {
+                                                    view_close_pane.update(cx, |this, cx| {
+                                                      this.close_active_pane(window, cx);
+                                                    });
+                                                  }),
+                                              )
+                                              .separator()
+                                              .item(
+                                                PopupMenuItem::new("Move Up")
+                                                  .icon(IconName::ArrowUp)
+                                                  .disabled(is_first)
+                                                  .on_click(move |_, _window, cx| {
+                                                    view_move_left.update(cx, |this, cx| {
+                                                      if tab_ix > 0 {
+                                                        this.items.swap(tab_ix, tab_ix - 1);
+                                                        this.active_tab_ix = Some(tab_ix - 1);
+                                                        cx.notify();
+                                                      }
+                                                    });
+                                                  }),
+                                              )
+                                              .item(
+                                                PopupMenuItem::new("Move Down")
+                                                  .icon(IconName::ArrowDown)
+                                                  .disabled(is_last)
+                                                  .on_click(move |_, _window, cx| {
+                                                    view_move_right.update(cx, |this, cx| {
+                                                      if tab_ix + 1 < this.items.len() {
+                                                        this.items.swap(tab_ix, tab_ix + 1);
+                                                        this.active_tab_ix = Some(tab_ix + 1);
+                                                        cx.notify();
+                                                      }
+                                                    });
+                                                  }),
+                                              )
+                                              .separator()
+                                              .item(
+                                                PopupMenuItem::new("Close Other Tabs")
+                                                  .icon(IconName::Close)
+                                                  .disabled(total_tabs <= 1)
+                                                  .on_click(move |_, _window, cx| {
+                                                    view_close_others.update(cx, |this, cx| {
+                                                      let keep_index = tab_index;
+                                                      this
+                                                        .items
+                                                        .retain(|tab| tab.index == keep_index);
+                                                      this.active_tab_ix = Some(0);
+                                                      cx.notify();
+                                                    });
+                                                  }),
+                                              )
+                                              .item(
+                                                PopupMenuItem::new("Close Tabs to Right")
+                                                  .icon(IconName::Close)
+                                                  .disabled(is_last)
+                                                  .on_click(move |_, _window, cx| {
+                                                    view_close_right.update(cx, |this, cx| {
+                                                      let right_ix = tab_ix + 1;
+                                                      if right_ix < this.items.len() {
+                                                        this.items.truncate(right_ix);
+                                                        this.active_tab_ix = Some(tab_ix);
+                                                        cx.notify();
+                                                      }
+                                                    });
+                                                  }),
+                                              )
+                                              .item(
+                                                PopupMenuItem::new("Close Tab")
+                                                  .icon(IconName::Close)
+                                                  .on_click(move |_, window, cx| {
+                                                    view_close_tab.update(cx, |this, cx| {
+                                                      this.remove_tab_by(tab_index, window, cx);
+                                                    });
+                                                  }),
+                                              )
+                                          }
+                                        }),
+                                    ),
                                 ),
                             )
                         })


### PR DESCRIPTION
This pull request introduces support for rendering terminal tabs vertically in a left sidebar, controlled by a new `vertical_tabs` configuration option. It updates the configuration schema, migration logic, and UI rendering to accommodate this feature. Additionally, it includes related test and code improvements to ensure smooth migration and correct UI behavior.

**Vertical tabs feature and config changes:**
- Added a new `vertical_tabs` boolean field to the `Config` struct, with default value `false`, and updated the config version to `20260220.1` (`crates/config/src/lib.rs`) [[1]](diffhunk://#diff-0f348074359029c2930eb72b52f482c2e0f4495dc61b95bc919f155a8d2fd82cR57-R58) [[2]](diffhunk://#diff-0f348074359029c2930eb72b52f482c2e0f4495dc61b95bc919f155a8d2fd82cR84) [[3]](diffhunk://#diff-0f348074359029c2930eb72b52f482c2e0f4495dc61b95bc919f155a8d2fd82cL37-R37).
- Implemented config migration logic to add the `vertical_tabs` field for users upgrading from the previous version, and updated `CURRENT_CONFIG_VERSION` and migration tests (`crates/config/src/migration.rs`) [[1]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L4-R4) [[2]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L22-R33) [[3]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718R46-R58) [[4]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718R129-R139) [[5]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718R170-R184).

**UI and rendering updates:**
- Updated the main window rendering logic to support vertical tab layout, including tab scrolling behavior and conditional rendering based on the `vertical_tabs` config (`crates/kazeterm/src/components/main_window_render.rs`) [[1]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7R24) [[2]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7R43-R54) [[3]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7R66-R79) [[4]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7L164-R177) [[5]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7R494).
- Refactored menu view handling to avoid unnecessary clones and ensure correct references for menu actions (`crates/kazeterm/src/components/main_window_render.rs`) [[1]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7R88-R90) [[2]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7L504-R518) [[3]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7L515-R529) [[4]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7L556-R570) [[5]](diffhunk://#diff-afd3e21c356d91f265afca03bb05044085bf302ae315c25a636afb48cf4daef7L597-R611).

**Testing and defaults:**
- Updated tests and config defaults to include the new `vertical_tabs` field and ensure correct migration and initialization (`crates/config/src/lib.rs`, `crates/config/src/migration.rs`) [[1]](diffhunk://#diff-0f348074359029c2930eb72b52f482c2e0f4495dc61b95bc919f155a8d2fd82cR434) [[2]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718R129-R139) [[3]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718R170-R184).