### PR TITLE
feat: support custom keybindings in config file

### DIFF
--- a/crates/config/src/keybinding.rs
+++ b/crates/config/src/keybinding.rs
@@ -1,0 +1,245 @@
+use serde::{Deserialize, Serialize};
+
+/// Configuration for custom keyboard shortcuts.
+///
+/// Each field maps an action name to a keystroke string using the format:
+/// `[modifier-]...[key]` where modifiers can be `ctrl`, `shift`, `alt`.
+///
+/// Examples: `"ctrl-shift-c"`, `"ctrl-tab"`, `"ctrl-="`, `"alt-1"`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct KeybindingConfig {
+  /// Copy selection to clipboard
+  pub copy: String,
+  /// Paste from clipboard
+  pub paste: String,
+  /// Zoom in terminal text
+  pub zoom_in: String,
+  /// Zoom out terminal text
+  pub zoom_out: String,
+  /// Reset zoom level
+  pub zoom_reset: String,
+  /// Switch to next tab
+  pub next_tab: String,
+  /// Switch to previous tab
+  pub previous_tab: String,
+  /// Toggle search bar
+  pub toggle_search: String,
+  /// Split pane horizontally
+  pub split_horizontal: String,
+  /// Split pane vertically
+  pub split_vertical: String,
+  /// Close active pane
+  pub close_pane: String,
+}
+
+impl Default for KeybindingConfig {
+  fn default() -> Self {
+    Self {
+      copy: "ctrl-shift-c".to_string(),
+      paste: "ctrl-shift-v".to_string(),
+      zoom_in: "ctrl-=".to_string(),
+      zoom_out: "ctrl--".to_string(),
+      zoom_reset: "ctrl-0".to_string(),
+      next_tab: "ctrl-tab".to_string(),
+      previous_tab: "ctrl-shift-tab".to_string(),
+      toggle_search: "ctrl-shift-f".to_string(),
+      split_horizontal: "ctrl-shift-d".to_string(),
+      split_vertical: "ctrl-shift-e".to_string(),
+      close_pane: "ctrl-shift-w".to_string(),
+    }
+  }
+}
+
+/// A parsed keybinding with separate modifier and key components.
+///
+/// Use [`ParsedKeybinding::parse`] to convert a keybinding string
+/// (e.g., `"ctrl-shift-c"`) into this structured form for matching
+/// against key events.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedKeybinding {
+  pub control: bool,
+  pub shift: bool,
+  pub alt: bool,
+  pub key: String,
+}
+
+impl ParsedKeybinding {
+  /// Parse a keybinding string like `"ctrl-shift-c"` into components.
+  ///
+  /// Recognized modifier prefixes: `ctrl-`, `shift-`, `alt-`.
+  /// Everything after modifiers is treated as the key name.
+  pub fn parse(s: &str) -> Self {
+    let mut remaining = s;
+    let mut control = false;
+    let mut shift = false;
+    let mut alt = false;
+
+    loop {
+      if let Some(rest) = remaining.strip_prefix("ctrl-") {
+        control = true;
+        remaining = rest;
+      } else if let Some(rest) = remaining.strip_prefix("shift-") {
+        shift = true;
+        remaining = rest;
+      } else if let Some(rest) = remaining.strip_prefix("alt-") {
+        alt = true;
+        remaining = rest;
+      } else {
+        break;
+      }
+    }
+
+    ParsedKeybinding {
+      control,
+      shift,
+      alt,
+      key: remaining.to_string(),
+    }
+  }
+
+  /// Check if this parsed keybinding matches the given key event parameters.
+  pub fn matches(&self, control: bool, shift: bool, alt: bool, key: &str) -> bool {
+    self.control == control && self.shift == shift && self.alt == alt && self.key == key
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parse_simple_key() {
+    let kb = ParsedKeybinding::parse("tab");
+    assert_eq!(
+      kb,
+      ParsedKeybinding {
+        control: false,
+        shift: false,
+        alt: false,
+        key: "tab".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn parse_single_modifier() {
+    let kb = ParsedKeybinding::parse("ctrl-c");
+    assert_eq!(
+      kb,
+      ParsedKeybinding {
+        control: true,
+        shift: false,
+        alt: false,
+        key: "c".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn parse_multiple_modifiers() {
+    let kb = ParsedKeybinding::parse("ctrl-shift-c");
+    assert_eq!(
+      kb,
+      ParsedKeybinding {
+        control: true,
+        shift: true,
+        alt: false,
+        key: "c".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn parse_all_modifiers() {
+    let kb = ParsedKeybinding::parse("ctrl-shift-alt-x");
+    assert_eq!(
+      kb,
+      ParsedKeybinding {
+        control: true,
+        shift: true,
+        alt: true,
+        key: "x".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn parse_minus_key() {
+    // "ctrl--" means ctrl + minus
+    let kb = ParsedKeybinding::parse("ctrl--");
+    assert_eq!(
+      kb,
+      ParsedKeybinding {
+        control: true,
+        shift: false,
+        alt: false,
+        key: "-".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn parse_equals_key() {
+    let kb = ParsedKeybinding::parse("ctrl-=");
+    assert_eq!(
+      kb,
+      ParsedKeybinding {
+        control: true,
+        shift: false,
+        alt: false,
+        key: "=".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn matches_keystroke() {
+    let kb = ParsedKeybinding::parse("ctrl-shift-c");
+    assert!(kb.matches(true, true, false, "c"));
+    assert!(!kb.matches(true, false, false, "c"));
+    assert!(!kb.matches(false, true, false, "c"));
+    assert!(!kb.matches(true, true, false, "v"));
+  }
+
+  #[test]
+  fn default_keybindings_parse_correctly() {
+    let config = KeybindingConfig::default();
+    let copy = ParsedKeybinding::parse(&config.copy);
+    assert!(copy.matches(true, true, false, "c"));
+
+    let zoom_in = ParsedKeybinding::parse(&config.zoom_in);
+    assert!(zoom_in.matches(true, false, false, "="));
+
+    let zoom_out = ParsedKeybinding::parse(&config.zoom_out);
+    assert!(zoom_out.matches(true, false, false, "-"));
+  }
+
+  #[test]
+  fn keybinding_config_deserialize_defaults() {
+    let toml_str = "";
+    let config: KeybindingConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.copy, "ctrl-shift-c");
+    assert_eq!(config.paste, "ctrl-shift-v");
+  }
+
+  #[test]
+  fn keybinding_config_deserialize_partial_override() {
+    let toml_str = r#"copy = "ctrl-c""#;
+    let config: KeybindingConfig = toml::from_str(toml_str).unwrap();
+    assert_eq!(config.copy, "ctrl-c");
+    // Non-specified fields use defaults
+    assert_eq!(config.paste, "ctrl-shift-v");
+    assert_eq!(config.next_tab, "ctrl-tab");
+  }
+
+  #[test]
+  fn keybinding_config_roundtrip() {
+    let config = KeybindingConfig::default();
+    let serialized = toml::to_string_pretty(&config).unwrap();
+    let deserialized: KeybindingConfig = toml::from_str(&serialized).unwrap();
+    assert_eq!(config.copy, deserialized.copy);
+    assert_eq!(config.paste, deserialized.paste);
+    assert_eq!(config.zoom_in, deserialized.zoom_in);
+  }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -22,6 +22,9 @@ pub use theme::{
 pub mod migration;
 pub use migration::CURRENT_CONFIG_VERSION;
 
+mod keybinding;
+pub use keybinding::{KeybindingConfig, ParsedKeybinding};
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Profile {
   pub name: String,
@@ -59,6 +62,8 @@ pub struct Config {
   /// Close the application when the last tab is closed
   /// When false (default), a new tab is created instead
   pub close_on_last_tab: bool,
+  /// Custom keyboard shortcuts
+  pub keybindings: KeybindingConfig,
 }
 
 impl Default for Config {
@@ -83,6 +88,7 @@ impl Default for Config {
       minimap_enabled: false,
       vertical_tabs: false,
       close_on_last_tab: true,
+      keybindings: KeybindingConfig::default(),
     }
   }
 }
@@ -433,6 +439,7 @@ mod tests {
       minimap_enabled: false,
       vertical_tabs: false,
       close_on_last_tab: true,
+      keybindings: KeybindingConfig::default(),
     };
 
     // get_profile

--- a/crates/config/src/migration.rs
+++ b/crates/config/src/migration.rs
@@ -1,7 +1,7 @@
 use toml::Value;
 
 /// Current config version in YYYYMMDD.Rev format.
-pub const CURRENT_CONFIG_VERSION: &str = "20260220.1";
+pub const CURRENT_CONFIG_VERSION: &str = "20260303.1";
 
 /// A migration that transforms raw TOML config from one version to the next.
 struct Migration {
@@ -30,6 +30,11 @@ fn migrations() -> &'static [Migration] {
       to_version: "20260220.1",
       migrate: migrate_v20260208_1_to_20260220_1,
     },
+    Migration {
+      from_version: "20260220.1",
+      to_version: "20260303.1",
+      migrate: migrate_v20260220_1_to_20260303_1,
+    },
   ]
 }
 
@@ -52,6 +57,16 @@ fn migrate_v20260208_1_to_20260220_1(value: &mut Value) {
     table.insert(
       "version".to_string(),
       Value::String("20260220.1".to_string()),
+    );
+  }
+}
+
+/// Add custom keybindings configuration support.
+fn migrate_v20260220_1_to_20260303_1(value: &mut Value) {
+  if let Value::Table(table) = value {
+    table.insert(
+      "version".to_string(),
+      Value::String("20260303.1".to_string()),
     );
   }
 }
@@ -137,6 +152,18 @@ font_size = 18.0
     .unwrap()
   }
 
+  fn make_20260220_config() -> Value {
+    toml::from_str(
+      r#"
+version = "20260220.1"
+theme = "one"
+font_size = 18.0
+vertical_tabs = false
+"#,
+    )
+    .unwrap()
+  }
+
   #[test]
   fn no_migration_needed_for_current_version() {
     let mut config = make_current_config();
@@ -179,6 +206,17 @@ font_size = 18.0
     assert_eq!(
       config.get("vertical_tabs").unwrap().as_bool().unwrap(),
       false
+    );
+  }
+
+  #[test]
+  fn migrate_20260220_bumps_version_for_keybindings() {
+    let mut config = make_20260220_config();
+    let migrated = apply_migrations(&mut config);
+    assert!(migrated);
+    assert_eq!(
+      config.get("version").unwrap().as_str().unwrap(),
+      CURRENT_CONFIG_VERSION
     );
   }
 

--- a/crates/kazeterm/src/components/main_window_render.rs
+++ b/crates/kazeterm/src/components/main_window_render.rs
@@ -1,3 +1,4 @@
+use config::ParsedKeybinding;
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::{
@@ -230,41 +231,38 @@ impl Render for MainWindow {
         // Track Ctrl state
         this.last_known_ctrl_state = e.keystroke.modifiers.control;
 
-        if e.keystroke.modifiers.control && e.keystroke.key == "tab" {
-          // Ctrl+Tab or Ctrl+Shift+Tab - just switch tabs without showing switcher
-          let forward = !e.keystroke.modifiers.shift;
+        let keybindings = &cx.global::<config::Config>().keybindings;
+        let mods = &e.keystroke.modifiers;
+        let key = &e.keystroke.key;
+
+        let kb_next = ParsedKeybinding::parse(&keybindings.next_tab);
+        let kb_prev = ParsedKeybinding::parse(&keybindings.previous_tab);
+        let kb_search = ParsedKeybinding::parse(&keybindings.toggle_search);
+        let kb_split_h = ParsedKeybinding::parse(&keybindings.split_horizontal);
+        let kb_split_v = ParsedKeybinding::parse(&keybindings.split_vertical);
+        let kb_close_pane = ParsedKeybinding::parse(&keybindings.close_pane);
+
+        if kb_next.matches(mods.control, mods.shift, mods.alt, key) {
           let current_ix = this.active_tab_ix.unwrap_or(0);
-          let next_ix = if forward {
-            (current_ix + 1) % this.items.len()
-          } else {
-            if current_ix == 0 {
-              this.items.len() - 1
-            } else {
-              current_ix - 1
-            }
-          };
+          let next_ix = (current_ix + 1) % this.items.len();
           this.set_active_tab(next_ix, window, cx);
-        } else if e.keystroke.modifiers.shift
-          && e.keystroke.modifiers.control
-          && e.keystroke.key == "f"
-        {
+        } else if kb_prev.matches(mods.control, mods.shift, mods.alt, key) {
+          let current_ix = this.active_tab_ix.unwrap_or(0);
+          let prev_ix = if current_ix == 0 {
+            this.items.len() - 1
+          } else {
+            current_ix - 1
+          };
+          this.set_active_tab(prev_ix, window, cx);
+        } else if kb_search.matches(mods.control, mods.shift, mods.alt, key) {
           this.toggle_search(window, cx);
         } else if e.keystroke.key == "Escape" && this.search_visible {
           this.toggle_search(window, cx);
-        } else if e.keystroke.modifiers.shift
-          && e.keystroke.modifiers.control
-          && e.keystroke.key == "d"
-        {
+        } else if kb_split_h.matches(mods.control, mods.shift, mods.alt, key) {
           this.split_pane_horizontal(window, cx);
-        } else if e.keystroke.modifiers.shift
-          && e.keystroke.modifiers.control
-          && e.keystroke.key == "e"
-        {
+        } else if kb_split_v.matches(mods.control, mods.shift, mods.alt, key) {
           this.split_pane_vertical(window, cx);
-        } else if e.keystroke.modifiers.shift
-          && e.keystroke.modifiers.control
-          && e.keystroke.key == "w"
-        {
+        } else if kb_close_pane.matches(mods.control, mods.shift, mods.alt, key) {
           this.close_active_pane(window, cx);
         }
       }))

--- a/crates/kazeterm/src/config_watcher.rs
+++ b/crates/kazeterm/src/config_watcher.rs
@@ -245,8 +245,11 @@ fn reload_config_and_theme(cx: &mut App, change_type: FileChangeType) {
       let settings = create_settings_store(&new_config, system_is_dark);
 
       // Update globals
-      cx.set_global(new_config);
+      cx.set_global(new_config.clone());
       cx.set_global(settings);
+
+      // Re-bind terminal keybindings with updated config
+      terminal::bind_terminal_keys(cx, &new_config.keybindings);
 
       // Re-initialize gpui-component theme
       themeing::SettingsStore::init_gpui_component_theme(cx);

--- a/crates/kazeterm/src/main.rs
+++ b/crates/kazeterm/src/main.rs
@@ -177,7 +177,7 @@ fn main() {
   app.run(move |cx: &mut App| {
     Assets.load_fonts(cx).unwrap();
     gpui_component::init(cx);
-    terminal::init(cx);
+    terminal::init(cx, &config.keybindings);
 
     cx.set_global(crate::config::create_settings_store(
       &config,

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -25,25 +25,32 @@ pub use terminal::{SelectionPhase, Terminal, TerminalEventListener};
 pub use terminal_bounds::TerminalBounds;
 pub use terminal_view::{TerminalEvent, TerminalView};
 
+use config::KeybindingConfig;
 use gpui::{App, KeyBinding};
 use terminal_view::{
   Copy, Paste, ScrollPageDown, ScrollPageUp, SendPageDown, SendPageUp, SendTab, SendTabPrev,
   ZoomIn, ZoomOut, ZoomReset,
 };
 
-pub fn init(cx: &mut App) {
+pub fn init(cx: &mut App, keybindings: &KeybindingConfig) {
   // Initialize ZoomState global
   cx.set_global(themeing::ZoomState::default());
 
+  bind_terminal_keys(cx, keybindings);
+}
+
+/// Register terminal keybindings from config.
+///
+/// This is also called during hot-reload to update bindings.
+pub fn bind_terminal_keys(cx: &mut App, keybindings: &KeybindingConfig) {
   cx.bind_keys([
     KeyBinding::new("tab", SendTab, Some("Terminal")),
     KeyBinding::new("shift-tab", SendTabPrev, Some("Terminal")),
-    KeyBinding::new("ctrl-shift-c", Copy, Some("Terminal")),
-    KeyBinding::new("ctrl-shift-v", Paste, Some("Terminal")),
-    // In alt screen mode (vim, less, etc.), send keys to the application
+    KeyBinding::new(&keybindings.copy, Copy, Some("Terminal")),
+    KeyBinding::new(&keybindings.paste, Paste, Some("Terminal")),
+    // Page up/down are context-dependent and not customizable
     KeyBinding::new("pageup", SendPageUp, Some("Terminal && screen == alt")),
     KeyBinding::new("pagedown", SendPageDown, Some("Terminal && screen == alt")),
-    // In normal mode, scroll the scrollback buffer
     KeyBinding::new("pageup", ScrollPageUp, Some("Terminal && screen == normal")),
     KeyBinding::new(
       "pagedown",
@@ -52,10 +59,8 @@ pub fn init(cx: &mut App) {
     ),
     KeyBinding::new("shift-pageup", ScrollPageUp, Some("Terminal")),
     KeyBinding::new("shift-pagedown", ScrollPageDown, Some("Terminal")),
-    // Zoom in/out
-    KeyBinding::new("ctrl-=", ZoomIn, Some("Terminal")),
-    KeyBinding::new("ctrl-+", ZoomIn, Some("Terminal")),
-    KeyBinding::new("ctrl--", ZoomOut, Some("Terminal")),
-    KeyBinding::new("ctrl-0", ZoomReset, Some("Terminal")),
+    KeyBinding::new(&keybindings.zoom_in, ZoomIn, Some("Terminal")),
+    KeyBinding::new(&keybindings.zoom_out, ZoomOut, Some("Terminal")),
+    KeyBinding::new(&keybindings.zoom_reset, ZoomReset, Some("Terminal")),
   ]);
 }


### PR DESCRIPTION
Add a [keybindings] section to kazeterm.toml that allows users to customize keyboard shortcuts. Supported actions: copy, paste, zoom_in, zoom_out, zoom_reset, next_tab, previous_tab, toggle_search, split_horizontal, split_vertical, close_pane.

- Add KeybindingConfig struct with defaults matching previous hardcoded values
- Add ParsedKeybinding helper for matching keystrokes against config strings
- Update terminal::init() to use configured keybindings for GPUI key bindings
- Update MainWindow on_key_down handler to use configured keybindings
- Support hot-reload of keybindings when config file changes
- Add config migration to version 20260303.1
- Add comprehensive tests for keybinding parsing and matching