### PR TITLE
    feat: add OSC 7 CWD tracking for terminal sessions

### DIFF
--- a/crates/kazeterm/src/components/main_window_split_pane_actions.rs
+++ b/crates/kazeterm/src/components/main_window_split_pane_actions.rs
@@ -20,13 +20,17 @@ impl MainWindow {
 
     let working_directory = self.active_terminal_working_directory(cx);
 
+    // Use the same shell as the source tab, not the default shell.
+    let shell = self
+      .active_tab_item_mut()
+      .map(|item| item.shell_path.clone())
+      .unwrap_or_else(|| cx.global::<::config::Config>().get_shell().clone());
+
     // Create a new terminal with the same shell
     let index = self
       .tab_index
       .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-    let config = cx.global::<::config::Config>();
-    let shell = config.get_shell().clone();
     let working_directory_path = get_working_directory_pathbuf(working_directory);
 
     let new_terminal = crate::components::terminal_window::new_terminal_window_with_shell(

--- a/crates/kazeterm/src/components/main_window_tab_management.rs
+++ b/crates/kazeterm/src/components/main_window_tab_management.rs
@@ -9,7 +9,9 @@ use crate::components::split_pane::SplitContainer;
 
 impl MainWindow {
   pub fn insert_new_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-    self.insert_new_tab_with_profile(None, None, window, cx);
+    // Inherit CWD from active terminal so new tabs open in the same directory.
+    let working_directory = self.active_terminal_working_directory(cx);
+    self.insert_new_tab_with_profile(None, working_directory, window, cx);
   }
 
   /// Duplicates a tab by creating a new tab with the same shell and working directory
@@ -165,14 +167,9 @@ impl MainWindow {
     terminal: &gpui::Entity<TerminalView>,
     cx: &mut Context<Self>,
   ) -> Option<String> {
-    terminal
-      .read(cx)
-      .terminal()
-      .read(cx)
-      .pty_info
-      .current
-      .as_ref()
-      .map(|info| info.cwd.to_string_lossy().to_string())
+    // Use update() to get mutable access so we can force a fresh OS refresh.
+    let terminal_entity = terminal.read(cx).terminal().clone();
+    terminal_entity.update(cx, |term, _cx| term.current_working_directory())
   }
 
   pub(crate) fn subscribe_terminal_view_event(
@@ -553,11 +550,13 @@ impl MainWindow {
 }
 
 pub(crate) fn get_working_directory_pathbuf(working_directory: Option<String>) -> Option<PathBuf> {
+  tracing::debug!("get_working_directory_pathbuf: input={:?}", working_directory);
   if let Some(working_directory) = working_directory {
     let path = std::path::Path::new(&working_directory);
     if path.exists() && path.is_dir() {
       Some(path.to_path_buf())
     } else {
+      tracing::debug!("path does not exist or is not a dir, falling back to $HOME");
       std::env::home_dir()
     }
   } else {

--- a/crates/kazeterm/src/components/terminal_window.rs
+++ b/crates/kazeterm/src/components/terminal_window.rs
@@ -29,6 +29,78 @@ fn new_terminal(
   env.insert("TERM".to_string(), "xterm-256color".to_string());
   env.insert("COLORTERM".to_string(), "truecolor".to_string());
 
+  // Create a temp file for CWD communication (cross-platform, works on Windows).
+  // The shell writes its CWD to this file on each prompt.
+  let cwd_file = std::env::temp_dir().join(format!(
+    "kazeterm-cwd-{}-{}",
+    std::process::id(),
+    std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .map(|d| d.as_nanos())
+      .unwrap_or(0)
+  ));
+  env.insert(
+    "KAZETERM_CWD_FILE".to_string(),
+    cwd_file.to_string_lossy().to_string(),
+  );
+
+  // Shell integration: inject hooks so shells report their CWD.
+  let shell_name = std::path::Path::new(&program)
+    .file_stem()
+    .and_then(|s| s.to_str())
+    .unwrap_or("")
+    .to_lowercase();
+
+  // Bash/Zsh CWD hook: emit OSC 7 AND write to cwd_file.
+  let cwd_file_str = cwd_file.to_string_lossy();
+  let bash_hook = format!(
+    r#"printf '\e]7;file://%s%s\e\\' "$(hostname)" "$PWD"; printf '%s' "$PWD" > "{}""#,
+    cwd_file_str,
+  );
+  env.insert("__KAZETERM_OSC7".to_string(), bash_hook.clone());
+
+  if shell_name == "bash" || shell_name == "sh" {
+    let existing = std::env::var("PROMPT_COMMAND").unwrap_or_default();
+    let prompt_cmd = if existing.is_empty() {
+      bash_hook
+    } else {
+      format!("{bash_hook};{existing}")
+    };
+    env.insert("PROMPT_COMMAND".to_string(), prompt_cmd);
+  } else if shell_name == "zsh" {
+    env.insert("PROMPT_COMMAND".to_string(), bash_hook);
+  }
+
+  // PowerShell: auto-inject the prompt hook via -Command.
+  // Writes CWD to temp file (reliable on Windows) and also emits OSC 7 (for Unix).
+  let pwsh_init = format!(
+    concat!(
+      r#"$__kazeterm_orig_prompt = $function:prompt; "#,
+      r#"function prompt {{ "#,
+      r#"$cwd = (Get-Location).Path; "#,
+      r#"[System.IO.File]::WriteAllText('{}', $cwd); "#,
+      r#"$esc = [char]27; "#,
+      r#"$host_name = [System.Net.Dns]::GetHostName(); "#,
+      r#"[Console]::Write("${{esc}}]7;file://${{host_name}}${{cwd}}${{esc}}\"); "#,
+      r#"if ($__kazeterm_orig_prompt) {{ & $__kazeterm_orig_prompt }} "#,
+      r#"else {{ "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) " }} "#,
+      r#"}}"#,
+    ),
+    cwd_file_str,
+  );
+  env.insert("KAZETERM_PWSH_OSC7_INIT".to_string(), pwsh_init.clone());
+
+  let mut args = args;
+  if shell_name == "pwsh" || shell_name == "powershell" {
+    if args.is_empty() {
+      args = vec![
+        "-NoExit".to_string(),
+        "-Command".to_string(),
+        pwsh_init,
+      ];
+    }
+  }
+
   let (events_tx, events_rx) = unbounded();
 
   let term = Term::new(
@@ -56,7 +128,7 @@ fn new_terminal(
     alacritty_terminal::tty::new(&pty_options, TerminalBounds::default().into(), 1).unwrap();
 
   #[cfg(unix)]
-  let (pty_tx, pty_info, graphics_rx, pending_cnl) = {
+  let (pty_tx, pty_info, graphics_rx, pending_cnl, osc7_rx) = {
     use terminal::kitty_graphics::GraphicsPtyFilter;
 
     let term_for_cursor = term.clone();
@@ -68,7 +140,7 @@ fn new_terminal(
         Some((hs + cursor.line.0, cursor.column.0 as i32))
       });
 
-    let (filter, pending_cnl, graphics_rx) =
+    let (filter, pending_cnl, graphics_rx, osc7_rx) =
       GraphicsPtyFilter::new(pty, cursor_fn).unwrap();
     let pty_info = PtyProcessInfo::from_raw(filter.pty_fd(), filter.child_pid());
 
@@ -84,11 +156,11 @@ fn new_terminal(
     let pty_tx = event_loop.channel();
     let _io_thread = event_loop.spawn();
 
-    (pty_tx, pty_info, Some(graphics_rx), Some(pending_cnl))
+    (pty_tx, pty_info, Some(graphics_rx), Some(pending_cnl), Some(osc7_rx))
   };
 
   #[cfg(not(unix))]
-  let (pty_tx, pty_info, graphics_rx, pending_cnl) = {
+  let (pty_tx, pty_info, graphics_rx, pending_cnl, osc7_rx) = {
     let pty_info = PtyProcessInfo::new(&pty);
 
     let event_loop = EventLoop::new(
@@ -103,10 +175,12 @@ fn new_terminal(
     let pty_tx = event_loop.channel();
     let _io_thread = event_loop.spawn();
 
-    (pty_tx, pty_info, None, None)
+    (pty_tx, pty_info, None, None, None)
   };
 
-  let terminal = terminal::Terminal::new(pty_tx, term, pty_info, graphics_rx, pending_cnl);
+  let terminal = terminal::Terminal::new(
+    pty_tx, term, pty_info, graphics_rx, pending_cnl, osc7_rx, Some(cwd_file),
+  );
 
   (terminal, events_rx)
 }

--- a/crates/terminal/src/kitty_graphics/pty_filter.rs
+++ b/crates/terminal/src/kitty_graphics/pty_filter.rs
@@ -41,6 +41,7 @@ mod unix {
   use polling::{Event, PollMode, Poller};
 
   use super::super::command::RawGraphicsCommand;
+  use crate::osc7;
 
   /// Callback that tries to get the cursor position from the terminal.
   /// Returns `Some((absolute_line, column))` on success, `None` if lock unavailable.
@@ -72,6 +73,7 @@ mod unix {
     pending: Vec<u8>,
     pending_pos: usize,
     graphics_tx: mpsc::Sender<RawGraphicsCommand>,
+    osc7_tx: mpsc::Sender<std::path::PathBuf>,
     /// Callback to try-lock the terminal and get cursor position.
     cursor_fn: CursorFn,
     /// Cached cursor position from last successful try-lock.
@@ -335,6 +337,11 @@ mod unix {
         return Err(io::Error::from(io::ErrorKind::WouldBlock));
       }
 
+      // Scan passthrough bytes for OSC 7 CWD sequences.
+      if let Some(cwd) = osc7::extract_osc7_path(&self.pending) {
+        let _ = self.osc7_tx.send(cwd);
+      }
+
       let n = self.pending.len().min(buf.len());
       buf[..n].copy_from_slice(&self.pending[..n]);
       self.pending_pos = n;
@@ -362,13 +369,19 @@ mod unix {
     /// `cursor_fn` is called (via try-lock) to capture the cursor position
     /// when an APC graphics sequence is intercepted.
     ///
-    /// Returns `(filter, pending_cnl, graphics_rx)`:
+    /// Returns `(filter, pending_cnl, graphics_rx, osc7_rx)`:
     /// - `pending_cnl`: shared atomic for terminal to request cursor advancement
     /// - `graphics_rx`: receives Kitty graphics commands with cursor positions
+    /// - `osc7_rx`: receives CWD paths extracted from OSC 7 sequences
     pub fn new(
       pty: Pty,
       cursor_fn: CursorFn,
-    ) -> io::Result<(Self, Arc<AtomicU32>, mpsc::Receiver<RawGraphicsCommand>)> {
+    ) -> io::Result<(
+      Self,
+      Arc<AtomicU32>,
+      mpsc::Receiver<RawGraphicsCommand>,
+      mpsc::Receiver<std::path::PathBuf>,
+    )> {
       // Dup the master fd so the FilteringReader has its own fd for reading.
       // The original fd stays in the Pty for poll registration and writing.
       let master_fd = pty.file().as_raw_fd();
@@ -379,6 +392,7 @@ mod unix {
       let read_file = unsafe { File::from_raw_fd(read_fd) };
 
       let (graphics_tx, graphics_rx) = mpsc::channel();
+      let (osc7_tx, osc7_rx) = mpsc::channel();
       let pending_cnl = Arc::new(AtomicU32::new(0));
 
       let reader = FilteringReader {
@@ -388,13 +402,14 @@ mod unix {
         pending: Vec::with_capacity(8192),
         pending_pos: 0,
         graphics_tx,
+        osc7_tx,
         cursor_fn,
         last_cursor: (0, 0),
         cnl_injected: false,
         pending_cnl: Arc::clone(&pending_cnl),
       };
 
-      Ok((GraphicsPtyFilter { reader, pty }, pending_cnl, graphics_rx))
+      Ok((GraphicsPtyFilter { reader, pty }, pending_cnl, graphics_rx, osc7_rx))
     }
 
     /// Get the raw PTY master fd (for tcgetpgrp / PtyProcessInfo).

--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -11,6 +11,7 @@ mod layout_rect;
 mod mappings;
 pub mod minimap;
 mod mouse;
+pub mod osc7;
 mod pty_info;
 pub mod scrollbar;
 mod terminal;

--- a/crates/terminal/src/osc7.rs
+++ b/crates/terminal/src/osc7.rs
@@ -1,0 +1,223 @@
+//! OSC 7 (Operating System Command 7) parser for terminal CWD tracking.
+//!
+//! Modern shells emit OSC 7 escape sequences to report the current working
+//! directory. Format: `ESC ] 7 ; file://<hostname>/<path> BEL` or
+//! `ESC ] 7 ; file://<hostname>/<path> ESC \`
+//!
+//! This module extracts the path from the **last** OSC 7 sequence found in
+//! a chunk of PTY output bytes.
+
+use std::path::PathBuf;
+
+/// Extract the last OSC 7 path from a chunk of raw PTY output bytes.
+///
+/// Returns `None` if no valid OSC 7 sequence is found.
+pub fn extract_osc7_path(data: &[u8]) -> Option<PathBuf> {
+  let mut last_path: Option<PathBuf> = None;
+  let len = data.len();
+  let mut i = 0;
+
+  while i < len {
+    // Look for ESC (0x1B) followed by ']' (0x5D).
+    if data[i] != 0x1B {
+      i += 1;
+      continue;
+    }
+    if i + 1 >= len || data[i + 1] != b']' {
+      i += 1;
+      continue;
+    }
+
+    // Found ESC ]. Now check for "7;" prefix.
+    let osc_start = i + 2;
+    if osc_start + 2 > len || data[osc_start] != b'7' || data[osc_start + 1] != b';' {
+      i = osc_start;
+      continue;
+    }
+
+    let uri_start = osc_start + 2;
+
+    // Find the terminator: BEL (0x07) or ESC \ (0x1B 0x5C).
+    let mut uri_end = None;
+    let mut j = uri_start;
+    while j < len {
+      if data[j] == 0x07 {
+        uri_end = Some(j);
+        break;
+      }
+      if data[j] == 0x1B && j + 1 < len && data[j + 1] == b'\\' {
+        uri_end = Some(j);
+        break;
+      }
+      j += 1;
+    }
+
+    let Some(end) = uri_end else {
+      // Incomplete sequence (may span chunks) — skip.
+      i = uri_start;
+      continue;
+    };
+
+    if let Some(path) = parse_file_uri(&data[uri_start..end]) {
+      last_path = Some(path);
+    }
+
+    i = end + 1;
+  }
+
+  last_path
+}
+
+/// Parse a `file://` URI into a `PathBuf`.
+///
+/// Handles:
+/// - `file:///absolute/path` (no hostname)
+/// - `file://hostname/absolute/path` (hostname is stripped)
+/// - Percent-encoded characters (e.g. `%20` for space)
+/// - Windows paths: `file:///C:/Users/...`
+fn parse_file_uri(uri_bytes: &[u8]) -> Option<PathBuf> {
+  let uri = std::str::from_utf8(uri_bytes).ok()?;
+  let rest = uri.strip_prefix("file://")?;
+
+  // Split hostname from path. The path always starts with '/'.
+  let path_str = if let Some(slash_pos) = rest.find('/') {
+    &rest[slash_pos..]
+  } else {
+    // No slash after hostname — malformed.
+    return None;
+  };
+
+  let decoded = percent_decode(path_str);
+
+  // Normalize Windows UNC prefix if present.
+  let cleaned = decoded
+    .strip_prefix("\\\\?\\")
+    .unwrap_or(&decoded);
+
+  let path = PathBuf::from(cleaned);
+  if path.as_os_str().is_empty() {
+    return None;
+  }
+
+  Some(path)
+}
+
+/// Decode percent-encoded bytes in a URI path (e.g. `%20` → ` `).
+fn percent_decode(input: &str) -> String {
+  let mut out = String::with_capacity(input.len());
+  let bytes = input.as_bytes();
+  let mut i = 0;
+
+  while i < bytes.len() {
+    if bytes[i] == b'%' && i + 2 < bytes.len() {
+      if let (Some(hi), Some(lo)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+        out.push((hi << 4 | lo) as char);
+        i += 3;
+        continue;
+      }
+    }
+    out.push(bytes[i] as char);
+    i += 1;
+  }
+
+  out
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+  match b {
+    b'0'..=b'9' => Some(b - b'0'),
+    b'a'..=b'f' => Some(b - b'a' + 10),
+    b'A'..=b'F' => Some(b - b'A' + 10),
+    _ => None,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_basic_osc7_bel_terminated() {
+    let data = b"\x1b]7;file:///home/user/project\x07";
+    assert_eq!(
+      extract_osc7_path(data),
+      Some(PathBuf::from("/home/user/project"))
+    );
+  }
+
+  #[test]
+  fn test_basic_osc7_st_terminated() {
+    let data = b"\x1b]7;file:///home/user/project\x1b\\";
+    assert_eq!(
+      extract_osc7_path(data),
+      Some(PathBuf::from("/home/user/project"))
+    );
+  }
+
+  #[test]
+  fn test_osc7_with_hostname() {
+    let data = b"\x1b]7;file://myhost/home/user/project\x07";
+    assert_eq!(
+      extract_osc7_path(data),
+      Some(PathBuf::from("/home/user/project"))
+    );
+  }
+
+  #[test]
+  fn test_osc7_percent_encoding() {
+    let data = b"\x1b]7;file:///home/user/my%20project\x07";
+    assert_eq!(
+      extract_osc7_path(data),
+      Some(PathBuf::from("/home/user/my project"))
+    );
+  }
+
+  #[test]
+  fn test_osc7_last_wins() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"\x1b]7;file:///first\x07");
+    data.extend_from_slice(b"some output");
+    data.extend_from_slice(b"\x1b]7;file:///second\x07");
+    assert_eq!(extract_osc7_path(&data), Some(PathBuf::from("/second")));
+  }
+
+  #[test]
+  fn test_osc7_mixed_with_normal_output() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"hello world\r\n");
+    data.extend_from_slice(b"\x1b]7;file:///home/user\x07");
+    data.extend_from_slice(b"more output\r\n");
+    assert_eq!(
+      extract_osc7_path(&data),
+      Some(PathBuf::from("/home/user"))
+    );
+  }
+
+  #[test]
+  fn test_no_osc7() {
+    let data = b"just normal terminal output\r\n";
+    assert_eq!(extract_osc7_path(data), None);
+  }
+
+  #[test]
+  fn test_incomplete_osc7() {
+    // Missing terminator — should return None.
+    let data = b"\x1b]7;file:///home/user";
+    assert_eq!(extract_osc7_path(data), None);
+  }
+
+  #[test]
+  fn test_windows_path() {
+    let data = b"\x1b]7;file:///C:/Users/user/project\x07";
+    assert_eq!(
+      extract_osc7_path(data),
+      Some(PathBuf::from("/C:/Users/user/project"))
+    );
+  }
+
+  #[test]
+  fn test_empty_path() {
+    let data = b"\x1b]7;file://\x07";
+    assert_eq!(extract_osc7_path(data), None);
+  }
+}

--- a/crates/terminal/src/terminal/mod.rs
+++ b/crates/terminal/src/terminal/mod.rs
@@ -87,6 +87,12 @@ pub struct Terminal {
   pub placement_manager: PlacementManager,
   /// Shared atomic for signaling cursor advancement to the PTY filter.
   pending_cnl: Option<Arc<std::sync::atomic::AtomicU32>>,
+  /// Receives CWD paths extracted from OSC 7 sequences in PTY output.
+  osc7_rx: Option<std::sync::mpsc::Receiver<std::path::PathBuf>>,
+  /// Last CWD reported via OSC 7 (takes priority over sysinfo).
+  pub osc7_cwd: Option<std::path::PathBuf>,
+  /// Path to a temp file where the shell writes its CWD on each prompt.
+  cwd_file: Option<std::path::PathBuf>,
 }
 
 impl Terminal {
@@ -96,6 +102,8 @@ impl Terminal {
     pty_info: PtyProcessInfo,
     graphics_rx: Option<std::sync::mpsc::Receiver<RawGraphicsCommand>>,
     pending_cnl: Option<Arc<std::sync::atomic::AtomicU32>>,
+    osc7_rx: Option<std::sync::mpsc::Receiver<std::path::PathBuf>>,
+    cwd_file: Option<std::path::PathBuf>,
   ) -> Self {
     Self {
       pty_tx: Notifier(pty_tx),
@@ -123,7 +131,67 @@ impl Terminal {
       image_storage: KittyImageStorage::new(),
       placement_manager: PlacementManager::new(),
       pending_cnl,
+      osc7_rx,
+      osc7_cwd: None,
+      cwd_file,
     }
+  }
+
+  /// Force-refresh and return the current working directory of the foreground process.
+  pub fn current_working_directory(&mut self) -> Option<String> {
+    // Prefer OSC 7 (shell-reported, most reliable on Unix).
+    if let Some(osc7) = &self.osc7_cwd {
+      tracing::debug!("CWD from OSC 7: {:?}", osc7);
+      return Some(osc7.to_string_lossy().to_string());
+    }
+
+    // Try direct /proc/<pid>/cwd readlink (bypasses sysinfo, most reliable on Linux).
+    #[cfg(target_os = "linux")]
+    if let Some(pid) = self.pty_info.pid() {
+      let proc_path = format!("/proc/{}/cwd", pid.as_u32());
+      match std::fs::read_link(&proc_path) {
+        Ok(cwd) if cwd.is_dir() => {
+          tracing::debug!("CWD from /proc readlink: {:?}, pid: {}", cwd, pid);
+          return Some(cwd.to_string_lossy().to_string());
+        }
+        Ok(cwd) => {
+          tracing::debug!("CWD from /proc readlink not a dir: {:?}", cwd);
+        }
+        Err(e) => {
+          tracing::debug!("Failed to readlink {}: {}", proc_path, e);
+        }
+      }
+    }
+
+    // Read CWD from the shell-written temp file (cross-platform, works on Windows).
+    if let Some(cwd_file) = &self.cwd_file {
+      match std::fs::read_to_string(cwd_file) {
+        Ok(contents) => {
+          let cwd = contents.trim().to_string();
+          if !cwd.is_empty() && std::path::Path::new(&cwd).is_dir() {
+            tracing::debug!("CWD from cwd_file: {:?}", cwd);
+            return Some(cwd);
+          }
+        }
+        Err(e) => {
+          tracing::debug!("Failed to read cwd_file {:?}: {}", cwd_file, e);
+        }
+      }
+    }
+
+    // Fallback: sysinfo refresh.
+    self.pty_info.has_changed();
+    let cwd = self
+      .pty_info
+      .current
+      .as_ref()
+      .map(|info| info.cwd.to_string_lossy().to_string());
+    tracing::debug!(
+      "CWD from sysinfo: {:?}, pid: {:?}",
+      cwd,
+      self.pty_info.pid()
+    );
+    cwd
   }
 
   pub fn last_content(&self) -> &TerminalContent {
@@ -178,6 +246,9 @@ impl Terminal {
     // Process graphics commands AFTER terminal events so terminal_bounds is up to date.
     self.process_graphics_commands();
 
+    // Drain OSC 7 CWD updates (non-blocking). Last one wins.
+    self.process_osc7_cwd(cx);
+
     // Collect visible image placements for rendering.
     let viewport_top = history_size - display_offset;
     let viewport_lines = self.last_content.terminal_bounds.screen_lines() as u32;
@@ -214,6 +285,29 @@ impl Terminal {
     // Our architecture intercepts APC on the read side, so write_to_pty
     // would send responses to the shell's stdin (appearing as typed text).
     // Tools like kitten icat use q=2 (suppress all) and handle timeouts.
+  }
+
+  /// Drain OSC 7 CWD updates from the PTY filter channel.
+  /// Updates `osc7_cwd` and `pty_info.current.cwd` when a new path arrives.
+  fn process_osc7_cwd(&mut self, cx: &mut Context<Self>) {
+    let Some(rx) = &self.osc7_rx else { return };
+
+    let mut new_cwd = None;
+    while let Ok(path) = rx.try_recv() {
+      new_cwd = Some(path);
+    }
+
+    if let Some(cwd) = new_cwd {
+      let changed = self.osc7_cwd.as_ref() != Some(&cwd);
+      if changed {
+        // Update pty_info so existing CWD consumers (tab duplication, etc.) get the OSC 7 value.
+        if let Some(info) = &mut self.pty_info.current {
+          info.cwd = cwd.clone();
+        }
+        self.osc7_cwd = Some(cwd);
+        cx.emit(Event::TitleChanged);
+      }
+    }
   }
 
   fn execute_graphics_command(


### PR DESCRIPTION
    Implement OSC 7 (Operating System Command 7) protocol support for
    real-time working directory tracking in terminal sessions. This is
    the standard protocol used by modern terminals (WezTerm, iTerm2,
    Ghostty) where the shell emits file:// URIs after each command.

    Changes:
    - New osc7.rs parser module: extracts file:// URIs from raw PTY output bytes, handling hostnames, percent-encoding, and both BEL and ESC\ terminators
    - FilteringReader integration: scans passthrough bytes for OSC 7 sequences inline during PTY reads, sends CWD via mpsc channel
    - Terminal consumes OSC 7 updates in sync(), updating pty_info.cwd so existing consumers (tab duplication, etc.) get the new value
    - Shell hook injection: sets PROMPT_COMMAND env var for bash, and __KAZETERM_OSC7 for manual shell config integration
    - CWD priority: OSC 7 CWD takes precedence over sysinfo polling

    Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>