### PR TITLE
Show error dialog when shell not found on terminal start

### DIFF
--- a/crates/kazeterm/src/components/main_window.rs
+++ b/crates/kazeterm/src/components/main_window.rs
@@ -7,6 +7,7 @@ use crate::components::about_dialog::AboutDialog;
 use crate::components::close_confirm_dialog::CloseConfirmDialog;
 use crate::components::import_alacritty_dialog::ImportAlacrittyDialog;
 use crate::components::search_bar::SearchBar;
+use crate::components::shell_error_dialog::ShellErrorDialog;
 use crate::components::tab_rename_dialog::TabRenameDialog;
 use crate::components::tab_switcher::TabSwitcher;
 use crate::components::workspace_state::WorkspaceState;
@@ -50,6 +51,9 @@ pub struct MainWindow {
   /// Import Alacritty config dialog state
   pub(crate) import_alacritty_dialog: Option<Entity<ImportAlacrittyDialog>>,
   pub(crate) _import_alacritty_subscription: Option<gpui::Subscription>,
+  /// Shell error dialog state
+  pub(crate) shell_error_dialog: Option<Entity<ShellErrorDialog>>,
+  pub(crate) _shell_error_subscription: Option<gpui::Subscription>,
   /// Tracks the last time an OS notification was sent, for throttling.
   pub(crate) last_notification_time: Option<std::time::Instant>,
   /// Whether the tab bar is currently visible
@@ -113,6 +117,8 @@ impl MainWindow {
       _about_dialog_subscription: None,
       import_alacritty_dialog: None,
       _import_alacritty_subscription: None,
+      shell_error_dialog: None,
+      _shell_error_subscription: None,
       last_notification_time: None,
       tab_bar_visible: true,
     };

--- a/crates/kazeterm/src/components/main_window_dialog_handlers.rs
+++ b/crates/kazeterm/src/components/main_window_dialog_handlers.rs
@@ -4,6 +4,7 @@ use super::main_window::MainWindow;
 use crate::components::about_dialog::{AboutDialog, AboutDialogCloseEvent};
 use crate::components::close_confirm_dialog::{CloseConfirmDialog, CloseConfirmEvent};
 use crate::components::import_alacritty_dialog::{ImportAlacrittyDialog, ImportAlacrittyEvent};
+use crate::components::shell_error_dialog::{ShellErrorCloseEvent, ShellErrorDialog};
 use crate::components::tab_rename_dialog::{TabRenameDialog, TabRenameEvent};
 
 impl MainWindow {
@@ -224,5 +225,33 @@ impl MainWindow {
   /// Helper to refocus the active terminal after closing dialogs
   pub fn refocus_active_terminal(&mut self, window: &mut Window, cx: &mut Context<Self>) {
     self.focus_active_terminal(window, cx);
+  }
+
+  /// Show shell error dialog
+  pub(crate) fn show_shell_error_dialog(
+    &mut self,
+    error_message: String,
+    window: &mut Window,
+    cx: &mut Context<Self>,
+  ) {
+    let dialog = cx.new(|cx| ShellErrorDialog::new(error_message, window, cx));
+    let subscription = cx.subscribe_in(&dialog, window, Self::on_shell_error_event);
+
+    self.shell_error_dialog = Some(dialog);
+    self._shell_error_subscription = Some(subscription);
+    cx.notify();
+  }
+
+  pub(crate) fn on_shell_error_event(
+    &mut self,
+    _dialog: &Entity<ShellErrorDialog>,
+    _event: &ShellErrorCloseEvent,
+    window: &mut Window,
+    cx: &mut Context<Self>,
+  ) {
+    self.shell_error_dialog = None;
+    self._shell_error_subscription = None;
+    self.refocus_active_terminal(window, cx);
+    cx.notify();
   }
 }

--- a/crates/kazeterm/src/components/main_window_render.rs
+++ b/crates/kazeterm/src/components/main_window_render.rs
@@ -607,6 +607,13 @@ impl Render for MainWindow {
             } else {
               this
             }
+          })
+          .when(self.shell_error_dialog.is_some(), |this| {
+            if let Some(shell_error_dialog) = &self.shell_error_dialog {
+              this.child(shell_error_dialog.clone())
+            } else {
+              this
+            }
           });
 
         if vertical_tabs {

--- a/crates/kazeterm/src/components/main_window_split_pane_actions.rs
+++ b/crates/kazeterm/src/components/main_window_split_pane_actions.rs
@@ -49,14 +49,21 @@ impl MainWindow {
 
     let working_directory_path = get_working_directory_pathbuf(working_directory);
 
-    let new_terminal = crate::components::terminal_window::new_terminal_window_with_shell(
+    let new_terminal = match crate::components::terminal_window::new_terminal_window_with_shell(
       window,
       index,
       &shell,
       vec![],
       working_directory_path,
       cx,
-    );
+    ) {
+      Ok(terminal) => terminal,
+      Err(err) => {
+        tracing::error!("Failed to start shell for split pane: {err}");
+        self.show_shell_error_dialog(err, window, cx);
+        return;
+      }
+    };
 
     // Subscribe to the new terminal
     let subscription = cx.subscribe_in(&new_terminal, window, Self::subscribe_terminal_view_event);

--- a/crates/kazeterm/src/components/main_window_tab_management.rs
+++ b/crates/kazeterm/src/components/main_window_tab_management.rs
@@ -95,14 +95,21 @@ impl MainWindow {
         )
       };
 
-    let terminal = crate::components::terminal_window::new_terminal_window_with_shell(
+    let terminal = match crate::components::terminal_window::new_terminal_window_with_shell(
       window,
       index,
       &shell_program,
       shell_args.clone(),
       working_directory,
       cx,
-    );
+    ) {
+      Ok(terminal) => terminal,
+      Err(err) => {
+        tracing::error!("Failed to start shell: {err}");
+        this.show_shell_error_dialog(err, window, cx);
+        return;
+      }
+    };
     let subscription = cx.subscribe_in(&terminal, window, Self::subscribe_terminal_view_event);
 
     let split_container = SplitContainer::new(terminal.clone());

--- a/crates/kazeterm/src/components/mod.rs
+++ b/crates/kazeterm/src/components/mod.rs
@@ -13,6 +13,7 @@ mod main_window_tab_switcher_logic;
 mod menu_builder;
 mod notifications;
 mod search_bar;
+mod shell_error_dialog;
 mod shell_icon;
 mod split_pane;
 mod split_pane_context_menu;

--- a/crates/kazeterm/src/components/shell_error_dialog.rs
+++ b/crates/kazeterm/src/components/shell_error_dialog.rs
@@ -1,0 +1,97 @@
+use gpui::*;
+use gpui_component::ActiveTheme;
+use gpui_component::button::{Button, ButtonVariants};
+
+#[derive(Clone)]
+pub struct ShellErrorCloseEvent;
+
+pub struct ShellErrorDialog {
+  focus_handle: FocusHandle,
+  error_message: String,
+}
+
+impl EventEmitter<ShellErrorCloseEvent> for ShellErrorDialog {}
+
+impl ShellErrorDialog {
+  pub fn new(error_message: String, window: &mut Window, cx: &mut Context<Self>) -> Self {
+    let focus_handle = cx.focus_handle();
+    window.focus(&focus_handle);
+    Self {
+      focus_handle,
+      error_message,
+    }
+  }
+
+  fn close(&mut self, cx: &mut Context<Self>) {
+    cx.emit(ShellErrorCloseEvent);
+  }
+}
+
+impl Focusable for ShellErrorDialog {
+  fn focus_handle(&self, _cx: &App) -> FocusHandle {
+    self.focus_handle.clone()
+  }
+}
+
+impl Render for ShellErrorDialog {
+  fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    let theme = cx.theme();
+
+    div()
+      .absolute()
+      .inset_0()
+      .flex()
+      .items_center()
+      .justify_center()
+      .bg(gpui::black().opacity(0.5))
+      .on_mouse_down(gpui::MouseButton::Left, |_, _, cx| {
+        cx.stop_propagation();
+      })
+      .on_key_down(cx.listener(|this, e: &KeyDownEvent, _window, cx| {
+        if e.keystroke.key == "escape" || e.keystroke.key == "enter" {
+          this.close(cx);
+        }
+      }))
+      .child(
+        div()
+          .track_focus(&self.focus_handle)
+          .bg(theme.popover)
+          .text_color(theme.popover_foreground)
+          .rounded_md()
+          .shadow_lg()
+          .border_1()
+          .border_color(theme.border)
+          .p_4()
+          .w(px(460.0))
+          .child(
+            div()
+              .flex()
+              .flex_col()
+              .gap_3()
+              .w_full()
+              .child(
+                div()
+                  .text_base()
+                  .font_weight(FontWeight::SEMIBOLD)
+                  .child("Failed to Start Shell"),
+              )
+              .child(
+                div()
+                  .text_sm()
+                  .text_color(theme.muted_foreground)
+                  .child(self.error_message.clone()),
+              )
+              .child(
+                gpui_component::h_flex().gap_2().justify_end().child(
+                  Button::new("ok")
+                    .primary()
+                    .label("OK")
+                    .on_click(cx.listener(|this, _, _window, cx| {
+                      this.close(cx);
+                    })),
+                ),
+              ),
+          ),
+      )
+  }
+}

--- a/crates/kazeterm/src/components/terminal_window.rs
+++ b/crates/kazeterm/src/components/terminal_window.rs
@@ -38,10 +38,13 @@ fn new_terminal(
   args: Vec<String>,
   working_directory: Option<PathBuf>,
   app_config: &config::Config,
-) -> (
-  terminal::Terminal,
-  futures::channel::mpsc::UnboundedReceiver<alacritty_terminal::event::Event>,
-) {
+) -> Result<
+  (
+    terminal::Terminal,
+    futures::channel::mpsc::UnboundedReceiver<alacritty_terminal::event::Event>,
+  ),
+  String,
+> {
   let mut env = std::collections::HashMap::new();
   if std::env::var("LANG").is_err() {
     env
@@ -141,6 +144,7 @@ fn new_terminal(
 
   let term = Arc::new(FairMutex::new(term));
 
+  let shell_program = program.clone();
   let pty_options = {
     let alac_shell = alacritty_terminal::tty::Shell::new(program, args);
 
@@ -155,7 +159,8 @@ fn new_terminal(
   };
 
   let pty =
-    alacritty_terminal::tty::new(&pty_options, TerminalBounds::default().into(), 1).unwrap();
+    alacritty_terminal::tty::new(&pty_options, TerminalBounds::default().into(), 1)
+      .map_err(|e| format!("Could not start shell '{}': {}", shell_program, e))?;
 
   #[cfg(unix)]
   let (pty_tx, pty_info, graphics_rx, pending_cnl, osc7_rx) = {
@@ -240,7 +245,7 @@ fn new_terminal(
     Some(cwd_file),
   );
 
-  (terminal, events_rx)
+  Ok((terminal, events_rx))
 }
 
 pub fn new_terminal_window_with_shell(
@@ -250,7 +255,7 @@ pub fn new_terminal_window_with_shell(
   args: Vec<String>,
   working_directory: Option<PathBuf>,
   cx: &mut Context<MainWindow>,
-) -> Entity<TerminalView> {
+) -> Result<Entity<TerminalView>, String> {
   let app_config = cx.global::<config::Config>().clone();
   // Use global working_directory as fallback if no per-profile working directory
   let working_directory = working_directory.or_else(|| {
@@ -260,7 +265,7 @@ pub fn new_terminal_window_with_shell(
       .map(|wd| PathBuf::from(wd))
   });
   let (terminal, events_rx) =
-    new_terminal(program.to_string(), args, working_directory, &app_config);
+    new_terminal(program.to_string(), args, working_directory, &app_config)?;
   let mut events_rx = events_rx;
   let terminal = cx.new(|_| terminal);
   let weak_terminal = terminal.downgrade();
@@ -327,5 +332,5 @@ pub fn new_terminal_window_with_shell(
   })
   .detach();
 
-  cx.new(|cx| TerminalView::new(terminal, window, index, cx))
+  Ok(cx.new(|cx| TerminalView::new(terminal, window, index, cx)))
 }

--- a/crates/kazeterm/src/components/workspace_state.rs
+++ b/crates/kazeterm/src/components/workspace_state.rs
@@ -186,7 +186,7 @@ impl MainWindow {
     cx: &mut Context<Self>,
   ) {
     let mut next_pane_id: usize = 0;
-    let (root_pane, subscriptions) = Self::build_split_pane(
+    let (root_pane, subscriptions) = match Self::build_split_pane(
       &tab_state.pane_tree,
       &tab_state.shell_path,
       &tab_state.shell_args,
@@ -194,7 +194,14 @@ impl MainWindow {
       &self.tab_index,
       window,
       cx,
-    );
+    ) {
+      Ok(result) => result,
+      Err(err) => {
+        tracing::error!("Failed to restore tab: {err}");
+        self.show_shell_error_dialog(err, window, cx);
+        return;
+      }
+    };
 
     // Find the first terminal pane id for active_pane_id
     let first_pane_id = Self::first_pane_id(&root_pane);
@@ -250,7 +257,7 @@ impl MainWindow {
     tab_index_counter: &std::sync::atomic::AtomicUsize,
     window: &mut Window,
     cx: &mut Context<MainWindow>,
-  ) -> (SplitPane, Vec<gpui::Subscription>) {
+  ) -> Result<(SplitPane, Vec<gpui::Subscription>), String> {
     match state {
       PaneTreeState::Terminal { working_directory } => {
         let index = tab_index_counter.fetch_add(1, Ordering::SeqCst);
@@ -262,11 +269,11 @@ impl MainWindow {
           tab_shell_args.to_vec(),
           wd,
           cx,
-        );
+        )?;
         let sub = cx.subscribe_in(&terminal, window, Self::subscribe_terminal_view_event);
         let pane_id = PaneId(*next_pane_id);
         *next_pane_id += 1;
-        (SplitPane::new_terminal(pane_id, terminal), vec![sub])
+        Ok((SplitPane::new_terminal(pane_id, terminal), vec![sub]))
       }
       PaneTreeState::Split {
         direction,
@@ -282,7 +289,7 @@ impl MainWindow {
           tab_index_counter,
           window,
           cx,
-        );
+        )?;
         let (second_pane, subs2) = Self::build_split_pane(
           second,
           tab_shell,
@@ -291,7 +298,7 @@ impl MainWindow {
           tab_index_counter,
           window,
           cx,
-        );
+        )?;
         subs.extend(subs2);
         let dir = match direction {
           SplitDirectionState::Horizontal => SplitDirection::Horizontal,
@@ -303,7 +310,7 @@ impl MainWindow {
           second: Box::new(second_pane),
           ratio: *ratio,
         };
-        (pane, subs)
+        Ok((pane, subs))
       }
     }
   }


### PR DESCRIPTION
Replace .unwrap() on PTY spawn with proper error handling. When the configured shell program cannot be found or fails to start, an error dialog is shown to the user instead of panicking.

Changes:
- new_terminal() and new_terminal_window_with_shell() now return Result
- Add ShellErrorDialog component following existing dialog patterns
- Handle spawn errors at all call sites: new tab, split pane, and workspace restore
- Log errors via tracing before showing the dialog