### PR TITLE
Refactor configuration structure and add color options

### DIFF
--- a/crates/config/src/alacritty_import.rs
+++ b/crates/config/src/alacritty_import.rs
@@ -215,13 +215,13 @@ pub fn import_alacritty_config_str(
 pub fn apply_import(config: &mut Config, result: AlacrittyImportResult) {
   let patch = result.config_patch;
   if let Some(v) = patch.font_family {
-    config.font_family = v;
+    config.font.family = v;
   }
   if let Some(v) = patch.font_size {
-    config.font_size = v;
+    config.font.size = v;
   }
   if let Some(v) = patch.background_opacity {
-    config.background_opacity = v;
+    config.appearance.background_opacity = v;
   }
   if let Some(profile) = patch.shell_profile {
     // Replace or add an "Alacritty" profile
@@ -232,31 +232,31 @@ pub fn apply_import(config: &mut Config, result: AlacrittyImportResult) {
     }
   }
   if let Some(v) = patch.scrollback_lines {
-    config.scrollback_lines = v;
+    config.terminal.scrollback_lines = v;
   }
   if let Some(v) = patch.cursor_shape {
-    config.cursor_shape = v;
+    config.cursor.shape = v;
   }
   if let Some(v) = patch.cursor_blink {
-    config.cursor_blink = v;
+    config.cursor.blink = v;
   }
   if let Some(v) = patch.cursor_blink_interval {
-    config.cursor_blink_interval = v;
+    config.cursor.blink_interval = v;
   }
   if let Some(v) = patch.osc52 {
-    config.osc52 = v;
+    config.terminal.osc52 = v;
   }
   if let Some(v) = patch.copy_on_select {
-    config.copy_on_select = v;
+    config.terminal.copy_on_select = v;
   }
   if !patch.env.is_empty() {
-    config.env = patch.env;
+    config.terminal.env = patch.env;
   }
   if let Some(v) = patch.working_directory {
-    config.working_directory = Some(v);
+    config.terminal.working_directory = Some(v);
   }
   if let Some(ref theme_file) = result.theme {
-    config.theme = theme_name_to_id(&theme_file.name);
+    config.appearance.theme = theme_name_to_id(&theme_file.name);
   }
 }
 
@@ -538,10 +538,10 @@ foreground = "#ffffff"
     let mut config = Config::default();
     apply_import(&mut config, result);
 
-    assert_eq!(config.font_family, "Fira Code");
-    assert_eq!(config.font_size, 16.0);
-    assert!((config.background_opacity - 0.85).abs() < 0.001);
-    assert_eq!(config.theme, "alacritty-import");
+    assert_eq!(config.font.family, "Fira Code");
+    assert_eq!(config.font.size, 16.0);
+    assert!((config.appearance.background_opacity - 0.85).abs() < 0.001);
+    assert_eq!(config.appearance.theme, "alacritty-import");
   }
 
   #[test]
@@ -685,13 +685,13 @@ working_directory = "/tmp"
     let mut config = Config::default();
     apply_import(&mut config, result);
 
-    assert_eq!(config.scrollback_lines, 5000);
-    assert_eq!(config.cursor_shape, "underline");
-    assert_eq!(config.cursor_blink, false);
-    assert_eq!(config.cursor_blink_interval, 600);
-    assert_eq!(config.osc52, "copy_paste");
-    assert_eq!(config.copy_on_select, true);
-    assert_eq!(config.env.get("MY_VAR").map(|s| s.as_str()), Some("test"));
-    assert_eq!(config.working_directory.as_deref(), Some("/tmp"));
+    assert_eq!(config.terminal.scrollback_lines, 5000);
+    assert_eq!(config.cursor.shape, "underline");
+    assert_eq!(config.cursor.blink, false);
+    assert_eq!(config.cursor.blink_interval, 600);
+    assert_eq!(config.terminal.osc52, "copy_paste");
+    assert_eq!(config.terminal.copy_on_select, true);
+    assert_eq!(config.terminal.env.get("MY_VAR").map(|s| s.as_str()), Some("test"));
+    assert_eq!(config.terminal.working_directory.as_deref(), Some("/tmp"));
   }
 }

--- a/crates/config/src/alacritty_import.rs
+++ b/crates/config/src/alacritty_import.rs
@@ -256,7 +256,7 @@ pub fn apply_import(config: &mut Config, result: AlacrittyImportResult) {
     config.terminal.working_directory = Some(v);
   }
   if let Some(ref theme_file) = result.theme {
-    config.appearance.theme = theme_name_to_id(&theme_file.name);
+    config.colors.theme = theme_name_to_id(&theme_file.name);
   }
 }
 
@@ -541,7 +541,7 @@ foreground = "#ffffff"
     assert_eq!(config.font.family, "Fira Code");
     assert_eq!(config.font.size, 16.0);
     assert!((config.appearance.background_opacity - 0.85).abs() < 0.001);
-    assert_eq!(config.appearance.theme, "alacritty-import");
+    assert_eq!(config.colors.theme, "alacritty-import");
   }
 
   #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -203,6 +203,8 @@ pub struct TerminalConfig {
   pub right_click_context_menu: bool,
   /// Enable the terminal minimap (shows a zoomed-out preview of scrollback).
   pub minimap_enabled: bool,
+  /// Use bright ANSI colors for bold text instead of only increasing font weight.
+  pub bold_is_bright: bool,
   /// Default working directory for new terminals.
   /// Per-profile working_directory takes priority over this setting.
   pub working_directory: Option<String>,
@@ -221,6 +223,7 @@ impl Default for TerminalConfig {
       copy_on_select: false,
       right_click_context_menu: true,
       minimap_enabled: false,
+      bold_is_bright: false,
       working_directory: None,
       default_profile: None,
       env: HashMap::new(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -36,9 +36,26 @@ pub use profiles::Profile;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
-pub struct AppearanceConfig {
+pub struct ColorsConfig {
   pub theme: String,
   pub theme_mode: ThemeMode,
+  /// Use bright ANSI colors for bold text instead of only increasing font weight.
+  pub bold_is_bright: bool,
+}
+
+impl Default for ColorsConfig {
+  fn default() -> Self {
+    Self {
+      theme: "one".to_string(),
+      theme_mode: ThemeMode::default(),
+      bold_is_bright: false,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct AppearanceConfig {
   /// Custom themes directory path.
   /// Themes in this directory take priority over embedded themes.
   pub themes_path: Option<String>,
@@ -53,8 +70,6 @@ pub struct AppearanceConfig {
 impl Default for AppearanceConfig {
   fn default() -> Self {
     Self {
-      theme: "one".to_string(),
-      theme_mode: ThemeMode::default(),
       themes_path: None,
       background_opacity: 1.0,
       background_blur: false,
@@ -203,8 +218,6 @@ pub struct TerminalConfig {
   pub right_click_context_menu: bool,
   /// Enable the terminal minimap (shows a zoomed-out preview of scrollback).
   pub minimap_enabled: bool,
-  /// Use bright ANSI colors for bold text instead of only increasing font weight.
-  pub bold_is_bright: bool,
   /// Default working directory for new terminals.
   /// Per-profile working_directory takes priority over this setting.
   pub working_directory: Option<String>,
@@ -223,7 +236,6 @@ impl Default for TerminalConfig {
       copy_on_select: false,
       right_click_context_menu: true,
       minimap_enabled: false,
-      bold_is_bright: false,
       working_directory: None,
       default_profile: None,
       env: HashMap::new(),
@@ -296,6 +308,7 @@ pub struct Config {
   /// Imported files override the base config, and later imports override earlier ones.
   #[serde(default)]
   pub imports: Vec<String>,
+  pub colors: ColorsConfig,
   pub appearance: AppearanceConfig,
   pub font: FontConfig,
   pub window: WindowConfig,
@@ -317,6 +330,7 @@ impl Default for Config {
     Self {
       version: CURRENT_CONFIG_VERSION.to_string(),
       imports: Vec::new(),
+      colors: ColorsConfig::default(),
       appearance: AppearanceConfig::default(),
       font: FontConfig::default(),
       window: WindowConfig::default(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -36,138 +36,33 @@ pub use profiles::Profile;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
-pub struct Config {
-  /// Config file version in YYYYMMDD.Rev format (e.g., "20260220.1")
-  pub version: String,
-  /// Additional config files to merge after the main `kazeterm.toml`.
-  /// Imported files override the base config, and later imports override earlier ones.
-  #[serde(default)]
-  pub imports: Vec<String>,
+pub struct AppearanceConfig {
   pub theme: String,
   pub theme_mode: ThemeMode,
-  /// Custom themes directory path
-  /// Themes in this directory take priority over embedded themes
+  /// Custom themes directory path.
+  /// Themes in this directory take priority over embedded themes.
   pub themes_path: Option<String>,
-  pub default_profile: Option<String>,
-  #[serde(default)]
-  pub profiles: Vec<Profile>,
-  pub font_size: f32,
-  pub font_family: String,
-  pub ui_font_family: String,
-  pub ui_font_size: f32,
-  pub window_width: f32,
-  pub window_height: f32,
-  /// Width of split pane divider drag handles in pixels.
-  pub split_pane_divider_width: f32,
-  /// Opacity applied to inactive (unfocused) split panes to visually distinguish them.
-  /// 0.0 = fully transparent, 1.0 = no dimming. Default is 0.6.
-  pub inactive_pane_opacity: f32,
-  /// Open the main window maximized on application startup.
-  pub start_maximized: bool,
-  #[serde(skip)]
-  pub container_profiles: Vec<Profile>,
-  /// Enable the terminal minimap (shows a zoomed-out preview of scrollback)
-  pub minimap_enabled: bool,
-  /// Render tabs vertically in a left sidebar instead of horizontally at the top
-  pub vertical_tabs: bool,
-  /// Close the application when the last tab is closed
-  /// When false (default), a new tab is created instead
-  pub close_on_last_tab: bool,
-  /// Show a tab switcher popup when using Ctrl+Tab / Ctrl+Shift+Tab
-  /// When false, tabs switch directly without showing a popup
-  pub tab_switcher_popup: bool,
-  /// Window background opacity (0.0 = fully transparent, 1.0 = fully opaque)
-  /// Values between 0.0 and 1.0 allow seeing through the terminal window
+  /// Window background opacity (0.0 = fully transparent, 1.0 = fully opaque).
+  /// Values between 0.0 and 1.0 allow seeing through the terminal window.
   pub background_opacity: f32,
   /// Blur the desktop background behind the window instead of plain transparency.
   /// Only takes effect when background_opacity < 1.0. Not supported on all platforms.
   pub background_blur: bool,
-  /// Custom keyboard shortcuts
-  pub keybindings: KeybindingConfig,
-  /// Minimum idle time (in seconds) since last input before a command completion
-  /// triggers a native OS notification. Set to 0 to notify on every prompt return.
-  pub long_running_threshold_secs: u64,
-  /// Minimum interval (in seconds) between consecutive OS notifications.
-  /// Prevents notification spam from rapid command completions.
-  /// Set to 0 to allow every notification. Default is 5 seconds.
-  pub notification_interval_secs: u64,
-  /// Delay before applying terminal-driven tab title changes, in milliseconds.
-  /// Helps avoid rapid title churn from shells or apps that update the title frequently.
-  pub tab_title_change_delay_ms: u64,
-  /// Maximum number of lines in the scrollback buffer.
-  /// Higher values use more memory. Default is 10000.
-  pub scrollback_lines: u32,
-  /// Default cursor shape: "block", "underline", or "beam"
-  pub cursor_shape: String,
-  /// Whether the cursor blinks
-  pub cursor_blink: bool,
-  /// Cursor blink interval in milliseconds
-  pub cursor_blink_interval: u64,
-  /// OSC 52 clipboard access mode: "disabled", "copy_only", "paste_only", "copy_paste"
-  pub osc52: String,
-  /// Automatically copy selected text to the clipboard
-  pub copy_on_select: bool,
-  /// Show a context menu on right-click instead of the default copy/paste behavior
-  pub right_click_context_menu: bool,
-  /// Additional environment variables to set for the terminal shell
-  #[serde(default)]
-  pub env: HashMap<String, String>,
-  /// Default working directory for new terminals.
-  /// Per-profile working_directory takes priority over this setting.
-  pub working_directory: Option<String>,
-  /// Automatically restore the previous workspace (tabs, splits, working directories)
-  /// on application launch. Default: true.
-  pub restore_workspace: bool,
 }
 
-impl Default for Config {
+impl Default for AppearanceConfig {
   fn default() -> Self {
     Self {
-      version: CURRENT_CONFIG_VERSION.to_string(),
-      imports: Vec::new(),
       theme: "one".to_string(),
       theme_mode: ThemeMode::default(),
       themes_path: None,
-      default_profile: None,
-      profiles: profiles::default_profiles(),
-      font_size: 18.0,
-      font_family: "Cascadia Code NF".to_string(),
-      #[cfg(target_os = "windows")]
-      ui_font_family: "Segoe UI".to_string(),
-      #[cfg(not(target_os = "windows"))]
-      ui_font_family: "Noto Sans".to_string(),
-      ui_font_size: 18.0,
-      window_width: 800.0,
-      window_height: 600.0,
-      split_pane_divider_width: 6.0,
-      inactive_pane_opacity: 0.6,
-      start_maximized: false,
-      container_profiles: profiles::detect_container_profiles(),
-      minimap_enabled: false,
-      vertical_tabs: false,
-      close_on_last_tab: true,
-      tab_switcher_popup: true,
       background_opacity: 1.0,
       background_blur: false,
-      keybindings: KeybindingConfig::default(),
-      long_running_threshold_secs: 10,
-      notification_interval_secs: 0,
-      tab_title_change_delay_ms: 200,
-      scrollback_lines: 10_000,
-      cursor_shape: "block".to_string(),
-      cursor_blink: true,
-      cursor_blink_interval: 750,
-      osc52: "copy_only".to_string(),
-      copy_on_select: false,
-      right_click_context_menu: true,
-      env: HashMap::new(),
-      working_directory: None,
-      restore_workspace: true,
     }
   }
 }
 
-impl Config {
+impl AppearanceConfig {
   /// Get the background opacity clamped to valid range [0.0, 1.0]
   pub fn get_background_opacity(&self) -> f32 {
     #[cfg(target_os = "linux")]
@@ -181,31 +76,260 @@ impl Config {
       (self.background_opacity / 2.0).clamp(0.0, 1.0)
     }
   }
+}
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct FontConfig {
+  pub size: f32,
+  pub family: String,
+  pub ui_family: String,
+  pub ui_size: f32,
+}
+
+impl Default for FontConfig {
+  fn default() -> Self {
+    Self {
+      size: 18.0,
+      family: "Cascadia Code NF".to_string(),
+      #[cfg(target_os = "windows")]
+      ui_family: "Segoe UI".to_string(),
+      #[cfg(not(target_os = "windows"))]
+      ui_family: "Noto Sans".to_string(),
+      ui_size: 18.0,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct WindowConfig {
+  pub width: f32,
+  pub height: f32,
+  /// Open the main window maximized on application startup.
+  pub start_maximized: bool,
+  /// Automatically restore the previous workspace (tabs, splits, working directories)
+  /// on application launch. Default: true.
+  pub restore_workspace: bool,
+}
+
+impl Default for WindowConfig {
+  fn default() -> Self {
+    Self {
+      width: 800.0,
+      height: 600.0,
+      start_maximized: false,
+      restore_workspace: true,
+    }
+  }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TabConfig {
+  /// Render tabs vertically in a left sidebar instead of horizontally at the top.
+  pub vertical: bool,
+  /// Close the application when the last tab is closed.
+  /// When false, a new tab is created instead.
+  pub close_on_last: bool,
+  /// Show a tab switcher popup when using Ctrl+Tab / Ctrl+Shift+Tab.
+  /// When false, tabs switch directly without showing a popup.
+  pub switcher_popup: bool,
+  /// Delay before applying terminal-driven tab title changes, in milliseconds.
+  /// Helps avoid rapid title churn from shells or apps that update the title frequently.
+  pub title_change_delay_ms: u64,
+}
+
+impl Default for TabConfig {
+  fn default() -> Self {
+    Self {
+      vertical: false,
+      close_on_last: true,
+      switcher_popup: true,
+      title_change_delay_ms: 200,
+    }
+  }
+}
+
+impl TabConfig {
+  /// Get the tab title change delay as Duration, clamped to [0, 5000] ms.
+  pub fn get_title_change_delay(&self) -> std::time::Duration {
+    std::time::Duration::from_millis(self.title_change_delay_ms.clamp(0, 5_000))
+  }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct PaneConfig {
+  /// Width of split pane divider drag handles in pixels.
+  pub divider_width: f32,
+  /// Opacity applied to inactive (unfocused) split panes to visually distinguish them.
+  /// 0.0 = fully transparent, 1.0 = no dimming. Default is 0.6.
+  pub inactive_opacity: f32,
+}
+
+impl Default for PaneConfig {
+  fn default() -> Self {
+    Self {
+      divider_width: 6.0,
+      inactive_opacity: 0.6,
+    }
+  }
+}
+
+impl PaneConfig {
+  /// Get split pane divider width clamped to a reasonable range in pixels.
+  pub fn get_divider_width(&self) -> f32 {
+    self.divider_width.clamp(1.0, 32.0)
+  }
+
+  /// Get inactive pane opacity clamped to [0.0, 1.0].
+  pub fn get_inactive_opacity(&self) -> f32 {
+    self.inactive_opacity.clamp(0.0, 1.0)
+  }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct TerminalConfig {
+  /// Maximum number of lines in the scrollback buffer.
+  /// Higher values use more memory. Default is 10000.
+  pub scrollback_lines: u32,
+  /// OSC 52 clipboard access mode: "disabled", "copy_only", "paste_only", "copy_paste"
+  pub osc52: String,
+  /// Automatically copy selected text to the clipboard.
+  pub copy_on_select: bool,
+  /// Show a context menu on right-click instead of the default copy/paste behavior.
+  pub right_click_context_menu: bool,
+  /// Enable the terminal minimap (shows a zoomed-out preview of scrollback).
+  pub minimap_enabled: bool,
+  /// Default working directory for new terminals.
+  /// Per-profile working_directory takes priority over this setting.
+  pub working_directory: Option<String>,
+  /// Default profile name for new terminals.
+  pub default_profile: Option<String>,
+  /// Additional environment variables to set for the terminal shell.
+  #[serde(default)]
+  pub env: HashMap<String, String>,
+}
+
+impl Default for TerminalConfig {
+  fn default() -> Self {
+    Self {
+      scrollback_lines: 10_000,
+      osc52: "copy_only".to_string(),
+      copy_on_select: false,
+      right_click_context_menu: true,
+      minimap_enabled: false,
+      working_directory: None,
+      default_profile: None,
+      env: HashMap::new(),
+    }
+  }
+}
+
+impl TerminalConfig {
   /// Get scrollback lines clamped to [0, 100_000]
   pub fn get_scrollback_lines(&self) -> usize {
     (self.scrollback_lines as usize).min(100_000)
   }
+}
 
-  /// Get split pane divider width clamped to a reasonable range in pixels.
-  pub fn get_split_pane_divider_width(&self) -> f32 {
-    self.split_pane_divider_width.clamp(1.0, 32.0)
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CursorConfig {
+  /// Default cursor shape: "block", "underline", or "beam"
+  pub shape: String,
+  /// Whether the cursor blinks.
+  pub blink: bool,
+  /// Cursor blink interval in milliseconds.
+  pub blink_interval: u64,
+}
+
+impl Default for CursorConfig {
+  fn default() -> Self {
+    Self {
+      shape: "block".to_string(),
+      blink: true,
+      blink_interval: 750,
+    }
   }
+}
 
-  /// Get inactive pane opacity clamped to [0.0, 1.0].
-  pub fn get_inactive_pane_opacity(&self) -> f32 {
-    self.inactive_pane_opacity.clamp(0.0, 1.0)
-  }
-
+impl CursorConfig {
   /// Get cursor blink interval as Duration, clamped to [10, 10000] ms
-  pub fn get_cursor_blink_interval(&self) -> std::time::Duration {
-    std::time::Duration::from_millis(self.cursor_blink_interval.clamp(10, 10_000))
+  pub fn get_blink_interval(&self) -> std::time::Duration {
+    std::time::Duration::from_millis(self.blink_interval.clamp(10, 10_000))
   }
+}
 
-  /// Get the tab title change delay as Duration, clamped to [0, 5000] ms.
-  pub fn get_tab_title_change_delay(&self) -> std::time::Duration {
-    std::time::Duration::from_millis(self.tab_title_change_delay_ms.clamp(0, 5_000))
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct NotificationConfig {
+  /// Minimum idle time (in seconds) since last input before a command completion
+  /// triggers a native OS notification. Set to 0 to notify on every prompt return.
+  pub long_running_threshold_secs: u64,
+  /// Minimum interval (in seconds) between consecutive OS notifications.
+  /// Prevents notification spam from rapid command completions.
+  /// Set to 0 to allow every notification.
+  pub interval_secs: u64,
+}
+
+impl Default for NotificationConfig {
+  fn default() -> Self {
+    Self {
+      long_running_threshold_secs: 10,
+      interval_secs: 0,
+    }
   }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct Config {
+  /// Config file version in YYYYMMDD.Rev format (e.g., "20260220.1")
+  pub version: String,
+  /// Additional config files to merge after the main `kazeterm.toml`.
+  /// Imported files override the base config, and later imports override earlier ones.
+  #[serde(default)]
+  pub imports: Vec<String>,
+  pub appearance: AppearanceConfig,
+  pub font: FontConfig,
+  pub window: WindowConfig,
+  pub tab: TabConfig,
+  pub pane: PaneConfig,
+  pub terminal: TerminalConfig,
+  pub cursor: CursorConfig,
+  pub notification: NotificationConfig,
+  #[serde(default)]
+  pub profiles: Vec<Profile>,
+  /// Custom keyboard shortcuts
+  pub keybindings: KeybindingConfig,
+  #[serde(skip)]
+  pub container_profiles: Vec<Profile>,
+}
+
+impl Default for Config {
+  fn default() -> Self {
+    Self {
+      version: CURRENT_CONFIG_VERSION.to_string(),
+      imports: Vec::new(),
+      appearance: AppearanceConfig::default(),
+      font: FontConfig::default(),
+      window: WindowConfig::default(),
+      tab: TabConfig::default(),
+      pane: PaneConfig::default(),
+      terminal: TerminalConfig::default(),
+      cursor: CursorConfig::default(),
+      notification: NotificationConfig::default(),
+      profiles: profiles::default_profiles(),
+      keybindings: KeybindingConfig::default(),
+      container_profiles: profiles::detect_container_profiles(),
+    }
+  }
+}
+
+impl Config {
 
   pub fn load() -> Self {
     let config_path = Self::get_config_file_path_impl();
@@ -623,12 +747,14 @@ mod tests {
       format!(
         r#"version = "{}"
 imports = ["./kazeterm.windows.toml"]
+
+[appearance]
 background_opacity = 1.0
 
 [keybindings]
 copy = "ctrl-shift-c"
 
-[env]
+[terminal.env]
 BASE = "from-base"
 "#,
         CURRENT_CONFIG_VERSION,
@@ -637,12 +763,13 @@ BASE = "from-base"
     .unwrap();
     std::fs::write(
       &overlay_path,
-      r#"background_opacity = 0.4
+      r#"[appearance]
+background_opacity = 0.4
 
 [keybindings]
 paste = "ctrl-alt-v"
 
-[env]
+[terminal.env]
 BASE = "from-overlay"
 EXTRA = "present"
 "#,
@@ -651,11 +778,11 @@ EXTRA = "present"
 
     let config = Config::load_from_path(&base_path).unwrap();
 
-    assert_eq!(config.background_opacity, 0.4);
+    assert_eq!(config.appearance.background_opacity, 0.4);
     assert_eq!(config.keybindings.copy, "ctrl-shift-c");
     assert_eq!(config.keybindings.paste, "ctrl-alt-v");
-    assert_eq!(config.env.get("BASE").unwrap(), "from-overlay");
-    assert_eq!(config.env.get("EXTRA").unwrap(), "present");
+    assert_eq!(config.terminal.env.get("BASE").unwrap(), "from-overlay");
+    assert_eq!(config.terminal.env.get("EXTRA").unwrap(), "present");
 
     std::fs::remove_dir_all(dir).unwrap();
   }
@@ -688,7 +815,7 @@ imports = ["./layer.toml"]
     )
     .unwrap();
     std::fs::write(&overlay_path, "imports = [\"./layer.local.toml\"]\n").unwrap();
-    std::fs::write(&nested_path, "background_opacity = 0.7\n").unwrap();
+    std::fs::write(&nested_path, "[appearance]\nbackground_opacity = 0.7\n").unwrap();
 
     let mut paths = vec![base_path.clone()];
     let mut visited = HashSet::from([Config::normalize_path(&base_path)]);

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -40,7 +40,7 @@ pub struct ColorsConfig {
   pub theme: String,
   pub theme_mode: ThemeMode,
   /// Use bright ANSI colors for bold text instead of only increasing font weight.
-  pub bold_is_bright: bool,
+  pub bold_as_bright: bool,
 }
 
 impl Default for ColorsConfig {
@@ -48,7 +48,7 @@ impl Default for ColorsConfig {
     Self {
       theme: "one".to_string(),
       theme_mode: ThemeMode::default(),
-      bold_is_bright: false,
+      bold_as_bright: false,
     }
   }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -41,6 +41,9 @@ pub struct ColorsConfig {
   pub theme_mode: ThemeMode,
   /// Use bright ANSI colors for bold text instead of only increasing font weight.
   pub bold_as_bright: bool,
+  /// Minimum APCA contrast between foreground and background colors.
+  /// Set to 0 to disable contrast enforcement. Default is 45.
+  pub minimum_contrast: f32,
 }
 
 impl Default for ColorsConfig {
@@ -49,6 +52,7 @@ impl Default for ColorsConfig {
       theme: "one".to_string(),
       theme_mode: ThemeMode::default(),
       bold_as_bright: false,
+      minimum_contrast: 45.0,
     }
   }
 }
@@ -218,9 +222,6 @@ pub struct TerminalConfig {
   pub right_click_context_menu: bool,
   /// Enable the terminal minimap (shows a zoomed-out preview of scrollback).
   pub minimap_enabled: bool,
-  /// Minimum APCA contrast between foreground and background colors.
-  /// Set to 0 to disable contrast enforcement. Default is 45.
-  pub minimum_contrast: f32,
   /// Default working directory for new terminals.
   /// Per-profile working_directory takes priority over this setting.
   pub working_directory: Option<String>,
@@ -239,7 +240,6 @@ impl Default for TerminalConfig {
       copy_on_select: false,
       right_click_context_menu: true,
       minimap_enabled: false,
-      minimum_contrast: 45.0,
       working_directory: None,
       default_profile: None,
       env: HashMap::new(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -218,6 +218,9 @@ pub struct TerminalConfig {
   pub right_click_context_menu: bool,
   /// Enable the terminal minimap (shows a zoomed-out preview of scrollback).
   pub minimap_enabled: bool,
+  /// Minimum APCA contrast between foreground and background colors.
+  /// Set to 0 to disable contrast enforcement. Default is 45.
+  pub minimum_contrast: f32,
   /// Default working directory for new terminals.
   /// Per-profile working_directory takes priority over this setting.
   pub working_directory: Option<String>,
@@ -236,6 +239,7 @@ impl Default for TerminalConfig {
       copy_on_select: false,
       right_click_context_menu: true,
       minimap_enabled: false,
+      minimum_contrast: 45.0,
       working_directory: None,
       default_profile: None,
       env: HashMap::new(),

--- a/crates/config/src/migration.rs
+++ b/crates/config/src/migration.rs
@@ -1,7 +1,7 @@
 use toml::Value;
 
 /// Current config version in YYYYMMDD.Rev format.
-pub const CURRENT_CONFIG_VERSION: &str = "20260414.1";
+pub const CURRENT_CONFIG_VERSION: &str = "20260414.2";
 
 /// A migration that transforms raw TOML config from one version to the next.
 struct Migration {
@@ -99,6 +99,11 @@ fn migrations() -> &'static [Migration] {
       from_version: "20260412.3",
       to_version: "20260414.1",
       migrate: migrate_v20260412_3_to_20260414_1,
+    },
+    Migration {
+      from_version: "20260414.1",
+      to_version: "20260414.2",
+      migrate: migrate_v20260414_1_to_20260414_2,
     },
   ]
 }
@@ -408,6 +413,46 @@ fn migrate_v20260412_3_to_20260414_1(value: &mut Value) {
   }
 }
 
+/// Move theme/theme_mode from [appearance] to [colors], and bold_is_bright from [terminal] to [colors].
+fn migrate_v20260414_1_to_20260414_2(value: &mut Value) {
+  if let Value::Table(table) = value {
+    // Move theme and theme_mode from appearance to colors
+    if let Some(Value::Table(appearance)) = table.get_mut("appearance") {
+      let theme = appearance.remove("theme");
+      let theme_mode = appearance.remove("theme_mode");
+
+      let colors = table
+        .entry("colors")
+        .or_insert_with(|| Value::Table(toml::map::Map::new()));
+      if let Value::Table(colors_table) = colors {
+        if let Some(v) = theme {
+          colors_table.insert("theme".to_string(), v);
+        }
+        if let Some(v) = theme_mode {
+          colors_table.insert("theme_mode".to_string(), v);
+        }
+      }
+    }
+
+    // Move bold_is_bright from terminal to colors
+    if let Some(Value::Table(terminal)) = table.get_mut("terminal") {
+      if let Some(v) = terminal.remove("bold_is_bright") {
+        let colors = table
+          .entry("colors")
+          .or_insert_with(|| Value::Table(toml::map::Map::new()));
+        if let Value::Table(colors_table) = colors {
+          colors_table.insert("bold_is_bright".to_string(), v);
+        }
+      }
+    }
+
+    table.insert(
+      "version".to_string(),
+      Value::String("20260414.2".to_string()),
+    );
+  }
+}
+
 /// Apply all necessary migrations to bring the config up to `CURRENT_CONFIG_VERSION`.
 /// Returns `true` if any migrations were applied, `false` if the config was already current.
 pub fn apply_migrations(value: &mut Value) -> bool {
@@ -471,7 +516,7 @@ font_family = "Cascadia Code NF"
       r#"
 version = "{}"
 
-[appearance]
+[colors]
 theme = "one"
 
 [font]
@@ -533,7 +578,7 @@ vertical_tabs = false
       CURRENT_CONFIG_VERSION
     );
     // Original fields are migrated to nested tables
-    assert_eq!(get_nested(&config, "appearance", "theme").unwrap().as_str().unwrap(), "one");
+    assert_eq!(get_nested(&config, "colors", "theme").unwrap().as_str().unwrap(), "one");
     assert_eq!(get_nested(&config, "font", "size").unwrap().as_float().unwrap(), 18.0);
   }
 
@@ -792,7 +837,7 @@ start_maximized = false
     apply_migrations(&mut raw);
     let config: crate::Config = raw.try_into().unwrap();
     assert_eq!(config.version, CURRENT_CONFIG_VERSION);
-    assert_eq!(config.appearance.theme, "one");
+    assert_eq!(config.colors.theme, "one");
     assert_eq!(config.font.size, 18.0);
     assert_eq!(config.pane.divider_width, 6.0);
     assert!(!config.window.start_maximized);

--- a/crates/config/src/migration.rs
+++ b/crates/config/src/migration.rs
@@ -413,7 +413,7 @@ fn migrate_v20260412_3_to_20260414_1(value: &mut Value) {
   }
 }
 
-/// Move theme/theme_mode from [appearance] to [colors], and bold_as_bright from [terminal] to [colors].
+/// Move theme/theme_mode from [appearance] to [colors], and bold_as_bright/minimum_contrast from [terminal] to [colors].
 fn migrate_v20260414_1_to_20260414_2(value: &mut Value) {
   if let Value::Table(table) = value {
     // Move theme and theme_mode from appearance to colors
@@ -434,14 +434,22 @@ fn migrate_v20260414_1_to_20260414_2(value: &mut Value) {
       }
     }
 
-    // Move bold_as_bright from terminal to colors
+    // Move bold_as_bright and minimum_contrast from terminal to colors
     if let Some(Value::Table(terminal)) = table.get_mut("terminal") {
-      if let Some(v) = terminal.remove("bold_as_bright") {
+      let bold = terminal.remove("bold_as_bright");
+      let contrast = terminal.remove("minimum_contrast");
+
+      if bold.is_some() || contrast.is_some() {
         let colors = table
           .entry("colors")
           .or_insert_with(|| Value::Table(toml::map::Map::new()));
         if let Value::Table(colors_table) = colors {
-          colors_table.insert("bold_as_bright".to_string(), v);
+          if let Some(v) = bold {
+            colors_table.insert("bold_as_bright".to_string(), v);
+          }
+          if let Some(v) = contrast {
+            colors_table.insert("minimum_contrast".to_string(), v);
+          }
         }
       }
     }

--- a/crates/config/src/migration.rs
+++ b/crates/config/src/migration.rs
@@ -1,7 +1,7 @@
 use toml::Value;
 
 /// Current config version in YYYYMMDD.Rev format.
-pub const CURRENT_CONFIG_VERSION: &str = "20260412.3";
+pub const CURRENT_CONFIG_VERSION: &str = "20260414.1";
 
 /// A migration that transforms raw TOML config from one version to the next.
 struct Migration {
@@ -94,6 +94,11 @@ fn migrations() -> &'static [Migration] {
       from_version: "20260412.2",
       to_version: "20260412.3",
       migrate: migrate_v20260412_2_to_20260412_3,
+    },
+    Migration {
+      from_version: "20260412.3",
+      to_version: "20260414.1",
+      migrate: migrate_v20260412_3_to_20260414_1,
     },
   ]
 }
@@ -316,6 +321,93 @@ fn migrate_v20260412_2_to_20260412_3(value: &mut Value) {
   }
 }
 
+/// Restructure flat config into nested TOML tables (appearance, font, window, etc.).
+fn migrate_v20260412_3_to_20260414_1(value: &mut Value) {
+  if let Value::Table(table) = value {
+    // Helper: move a key from root into a sub-table, creating the sub-table if needed.
+    fn move_key(table: &mut toml::map::Map<String, Value>, key: &str, section: &str) {
+      if let Some(val) = table.remove(key) {
+        let sub = table
+          .entry(section)
+          .or_insert_with(|| Value::Table(toml::map::Map::new()));
+        if let Value::Table(sub_table) = sub {
+          sub_table.insert(key.to_string(), val);
+        }
+      }
+    }
+
+    // Helper: move a key from root into a sub-table under a different name.
+    fn move_key_rename(
+      table: &mut toml::map::Map<String, Value>,
+      old_key: &str,
+      new_key: &str,
+      section: &str,
+    ) {
+      if let Some(val) = table.remove(old_key) {
+        let sub = table
+          .entry(section)
+          .or_insert_with(|| Value::Table(toml::map::Map::new()));
+        if let Value::Table(sub_table) = sub {
+          sub_table.insert(new_key.to_string(), val);
+        }
+      }
+    }
+
+    // [appearance]
+    move_key(table, "theme", "appearance");
+    move_key(table, "theme_mode", "appearance");
+    move_key(table, "themes_path", "appearance");
+    move_key(table, "background_opacity", "appearance");
+    move_key(table, "background_blur", "appearance");
+
+    // [font]
+    move_key_rename(table, "font_size", "size", "font");
+    move_key_rename(table, "font_family", "family", "font");
+    move_key_rename(table, "ui_font_family", "ui_family", "font");
+    move_key_rename(table, "ui_font_size", "ui_size", "font");
+
+    // [window]
+    move_key_rename(table, "window_width", "width", "window");
+    move_key_rename(table, "window_height", "height", "window");
+    move_key(table, "start_maximized", "window");
+    move_key(table, "restore_workspace", "window");
+
+    // [tab]
+    move_key_rename(table, "vertical_tabs", "vertical", "tab");
+    move_key_rename(table, "close_on_last_tab", "close_on_last", "tab");
+    move_key_rename(table, "tab_switcher_popup", "switcher_popup", "tab");
+    move_key_rename(table, "tab_title_change_delay_ms", "title_change_delay_ms", "tab");
+
+    // [pane]
+    move_key_rename(table, "split_pane_divider_width", "divider_width", "pane");
+    move_key_rename(table, "inactive_pane_opacity", "inactive_opacity", "pane");
+
+    // [terminal]
+    move_key(table, "scrollback_lines", "terminal");
+    move_key(table, "osc52", "terminal");
+    move_key(table, "copy_on_select", "terminal");
+    move_key(table, "right_click_context_menu", "terminal");
+    move_key(table, "minimap_enabled", "terminal");
+    move_key(table, "working_directory", "terminal");
+    move_key(table, "default_profile", "terminal");
+    move_key(table, "env", "terminal");
+
+    // [cursor]
+    move_key_rename(table, "cursor_shape", "shape", "cursor");
+    move_key_rename(table, "cursor_blink", "blink", "cursor");
+    move_key_rename(table, "cursor_blink_interval", "blink_interval", "cursor");
+
+    // [notification]
+    move_key(table, "long_running_threshold_secs", "notification");
+    move_key_rename(table, "notification_interval_secs", "interval_secs", "notification");
+
+    table.insert(
+      "version".to_string(),
+      Value::String("20260414.1".to_string()),
+    );
+  }
+}
+
 /// Apply all necessary migrations to bring the config up to `CURRENT_CONFIG_VERSION`.
 /// Returns `true` if any migrations were applied, `false` if the config was already current.
 pub fn apply_migrations(value: &mut Value) -> bool {
@@ -378,8 +470,12 @@ font_family = "Cascadia Code NF"
     toml::from_str(&format!(
       r#"
 version = "{}"
+
+[appearance]
 theme = "one"
-font_size = 18.0
+
+[font]
+size = 18.0
 "#,
       CURRENT_CONFIG_VERSION
     ))
@@ -420,6 +516,11 @@ vertical_tabs = false
     );
   }
 
+  /// Helper to access a nested value by section.key path.
+  fn get_nested<'a>(config: &'a Value, section: &str, key: &str) -> Option<&'a Value> {
+    config.get(section).and_then(|s| s.get(key))
+  }
+
   #[test]
   fn migrate_from_v0_adds_version() {
     let mut config = make_v0_config();
@@ -431,9 +532,9 @@ vertical_tabs = false
       config.get("version").unwrap().as_str().unwrap(),
       CURRENT_CONFIG_VERSION
     );
-    // Original fields are preserved
-    assert_eq!(config.get("theme").unwrap().as_str().unwrap(), "one");
-    assert_eq!(config.get("font_size").unwrap().as_float().unwrap(), 18.0);
+    // Original fields are migrated to nested tables
+    assert_eq!(get_nested(&config, "appearance", "theme").unwrap().as_str().unwrap(), "one");
+    assert_eq!(get_nested(&config, "font", "size").unwrap().as_float().unwrap(), 18.0);
   }
 
   #[test]
@@ -446,7 +547,7 @@ vertical_tabs = false
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config.get("vertical_tabs").unwrap().as_bool().unwrap(),
+      get_nested(&config, "tab", "vertical").unwrap().as_bool().unwrap(),
       false
     );
   }
@@ -479,8 +580,7 @@ font_size = 18.0
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config
-        .get("background_opacity")
+      get_nested(&config, "appearance", "background_opacity")
         .unwrap()
         .as_float()
         .unwrap(),
@@ -506,29 +606,27 @@ background_opacity = 0.9
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config
-        .get("scrollback_lines")
+      get_nested(&config, "terminal", "scrollback_lines")
         .unwrap()
         .as_integer()
         .unwrap(),
       10_000
     );
     assert_eq!(
-      config.get("cursor_shape").unwrap().as_str().unwrap(),
+      get_nested(&config, "cursor", "shape").unwrap().as_str().unwrap(),
       "block"
     );
-    assert_eq!(config.get("cursor_blink").unwrap().as_bool().unwrap(), true);
+    assert_eq!(get_nested(&config, "cursor", "blink").unwrap().as_bool().unwrap(), true);
     assert_eq!(
-      config
-        .get("cursor_blink_interval")
+      get_nested(&config, "cursor", "blink_interval")
         .unwrap()
         .as_integer()
         .unwrap(),
       750
     );
-    assert_eq!(config.get("osc52").unwrap().as_str().unwrap(), "copy_only");
+    assert_eq!(get_nested(&config, "terminal", "osc52").unwrap().as_str().unwrap(), "copy_only");
     assert_eq!(
-      config.get("copy_on_select").unwrap().as_bool().unwrap(),
+      get_nested(&config, "terminal", "copy_on_select").unwrap().as_bool().unwrap(),
       false
     );
   }
@@ -568,7 +666,7 @@ background_opacity = 0.8
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config.get("background_blur").unwrap().as_bool().unwrap(),
+      get_nested(&config, "appearance", "background_blur").unwrap().as_bool().unwrap(),
       false
     );
   }
@@ -591,8 +689,7 @@ background_blur = false
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config
-        .get("right_click_context_menu")
+      get_nested(&config, "terminal", "right_click_context_menu")
         .unwrap()
         .as_bool()
         .unwrap(),
@@ -618,8 +715,7 @@ imports = []
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config
-        .get("tab_title_change_delay_ms")
+      get_nested(&config, "tab", "title_change_delay_ms")
         .unwrap()
         .as_integer()
         .unwrap(),
@@ -658,7 +754,7 @@ font_size = 18.0
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config.get("start_maximized").unwrap().as_bool().unwrap(),
+      get_nested(&config, "window", "start_maximized").unwrap().as_bool().unwrap(),
       false
     );
   }
@@ -682,8 +778,7 @@ start_maximized = false
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config
-        .get("split_pane_divider_width")
+      get_nested(&config, "pane", "divider_width")
         .unwrap()
         .as_float()
         .unwrap(),
@@ -697,11 +792,11 @@ start_maximized = false
     apply_migrations(&mut raw);
     let config: crate::Config = raw.try_into().unwrap();
     assert_eq!(config.version, CURRENT_CONFIG_VERSION);
-    assert_eq!(config.theme, "one");
-    assert_eq!(config.font_size, 18.0);
-    assert_eq!(config.split_pane_divider_width, 6.0);
-    assert!(!config.start_maximized);
-    assert!((config.inactive_pane_opacity - 0.6).abs() < 0.001);
+    assert_eq!(config.appearance.theme, "one");
+    assert_eq!(config.font.size, 18.0);
+    assert_eq!(config.pane.divider_width, 6.0);
+    assert!(!config.window.start_maximized);
+    assert!((config.pane.inactive_opacity - 0.6).abs() < 0.001);
   }
 
   #[test]
@@ -723,8 +818,7 @@ split_pane_divider_width = 6.0
       CURRENT_CONFIG_VERSION
     );
     assert_eq!(
-      config
-        .get("inactive_pane_opacity")
+      get_nested(&config, "pane", "inactive_opacity")
         .unwrap()
         .as_float()
         .unwrap(),

--- a/crates/config/src/migration.rs
+++ b/crates/config/src/migration.rs
@@ -413,7 +413,7 @@ fn migrate_v20260412_3_to_20260414_1(value: &mut Value) {
   }
 }
 
-/// Move theme/theme_mode from [appearance] to [colors], and bold_is_bright from [terminal] to [colors].
+/// Move theme/theme_mode from [appearance] to [colors], and bold_as_bright from [terminal] to [colors].
 fn migrate_v20260414_1_to_20260414_2(value: &mut Value) {
   if let Value::Table(table) = value {
     // Move theme and theme_mode from appearance to colors
@@ -434,14 +434,14 @@ fn migrate_v20260414_1_to_20260414_2(value: &mut Value) {
       }
     }
 
-    // Move bold_is_bright from terminal to colors
+    // Move bold_as_bright from terminal to colors
     if let Some(Value::Table(terminal)) = table.get_mut("terminal") {
-      if let Some(v) = terminal.remove("bold_is_bright") {
+      if let Some(v) = terminal.remove("bold_as_bright") {
         let colors = table
           .entry("colors")
           .or_insert_with(|| Value::Table(toml::map::Map::new()));
         if let Value::Table(colors_table) = colors {
-          colors_table.insert("bold_is_bright".to_string(), v);
+          colors_table.insert("bold_as_bright".to_string(), v);
         }
       }
     }

--- a/crates/config/src/profiles.rs
+++ b/crates/config/src/profiles.rs
@@ -155,8 +155,9 @@ impl Config {
 #[cfg(test)]
 mod tests {
   use crate::{
-    CURRENT_CONFIG_VERSION, AppearanceConfig, Config, CursorConfig, FontConfig, KeybindingConfig,
-    NotificationConfig, PaneConfig, Profile, TabConfig, TerminalConfig, ThemeMode, WindowConfig,
+    CURRENT_CONFIG_VERSION, AppearanceConfig, ColorsConfig, Config, CursorConfig, FontConfig,
+    KeybindingConfig, NotificationConfig, PaneConfig, Profile, TabConfig, TerminalConfig,
+    ThemeMode, WindowConfig,
   };
 
   #[test]
@@ -179,9 +180,12 @@ mod tests {
     let config = Config {
       version: CURRENT_CONFIG_VERSION.to_string(),
       imports: vec![],
-      appearance: AppearanceConfig {
+      colors: ColorsConfig {
         theme: "one".into(),
         theme_mode: ThemeMode::Dark,
+        bold_is_bright: false,
+      },
+      appearance: AppearanceConfig {
         themes_path: None,
         background_opacity: 1.0,
         background_blur: false,

--- a/crates/config/src/profiles.rs
+++ b/crates/config/src/profiles.rs
@@ -79,7 +79,7 @@ impl Config {
       return None;
     }
 
-    if let Some(ref default_name) = self.default_profile {
+    if let Some(ref default_name) = self.terminal.default_profile {
       tracing::debug!("Looking for default profile: {}", default_name);
       if let Some(profile) = self.profiles.iter().find(|p| &p.name == default_name) {
         return Some(profile);
@@ -154,9 +154,10 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-  use std::collections::HashMap;
-
-  use crate::{CURRENT_CONFIG_VERSION, Config, KeybindingConfig, Profile, ThemeMode};
+  use crate::{
+    CURRENT_CONFIG_VERSION, AppearanceConfig, Config, CursorConfig, FontConfig, KeybindingConfig,
+    NotificationConfig, PaneConfig, Profile, TabConfig, TerminalConfig, ThemeMode, WindowConfig,
+  };
 
   #[test]
   fn get_profile_helpers() {
@@ -178,44 +179,39 @@ mod tests {
     let config = Config {
       version: CURRENT_CONFIG_VERSION.to_string(),
       imports: vec![],
-      theme: "one".into(),
-      theme_mode: ThemeMode::Dark,
-      themes_path: None,
-      default_profile: Some("two".into()),
+      appearance: AppearanceConfig {
+        theme: "one".into(),
+        theme_mode: ThemeMode::Dark,
+        themes_path: None,
+        background_opacity: 1.0,
+        background_blur: false,
+      },
+      font: FontConfig {
+        size: 12.0,
+        family: "Cascadia Code".into(),
+        #[cfg(target_os = "windows")]
+        ui_family: "Segoe UI".into(),
+        #[cfg(not(target_os = "windows"))]
+        ui_family: "Noto Sans".into(),
+        ui_size: 12.0,
+      },
+      window: WindowConfig {
+        width: 100.0,
+        height: 50.0,
+        start_maximized: false,
+        restore_workspace: true,
+      },
+      tab: TabConfig::default(),
+      pane: PaneConfig::default(),
+      terminal: TerminalConfig {
+        default_profile: Some("two".into()),
+        ..TerminalConfig::default()
+      },
+      cursor: CursorConfig::default(),
+      notification: NotificationConfig::default(),
       profiles: profiles.clone(),
-      font_size: 12.0,
-      font_family: "Cascadia Code".into(),
-      #[cfg(target_os = "windows")]
-      ui_font_family: "Segoe UI".into(),
-      #[cfg(not(target_os = "windows"))]
-      ui_font_family: "Noto Sans".into(),
-      ui_font_size: 12.0,
-      window_width: 100.0,
-      window_height: 50.0,
-      split_pane_divider_width: 6.0,
-      inactive_pane_opacity: 0.6,
-      start_maximized: false,
-      container_profiles: vec![],
-      minimap_enabled: false,
-      vertical_tabs: false,
-      close_on_last_tab: true,
-      tab_switcher_popup: true,
-      background_opacity: 1.0,
-      background_blur: false,
       keybindings: KeybindingConfig::default(),
-      long_running_threshold_secs: 10,
-      notification_interval_secs: 0,
-      tab_title_change_delay_ms: 200,
-      scrollback_lines: 10_000,
-      cursor_shape: "block".into(),
-      cursor_blink: true,
-      cursor_blink_interval: 750,
-      osc52: "copy_only".into(),
-      copy_on_select: false,
-      right_click_context_menu: true,
-      restore_workspace: true,
-      env: HashMap::new(),
-      working_directory: None,
+      container_profiles: vec![],
     };
 
     // get_profile

--- a/crates/config/src/profiles.rs
+++ b/crates/config/src/profiles.rs
@@ -183,7 +183,7 @@ mod tests {
       colors: ColorsConfig {
         theme: "one".into(),
         theme_mode: ThemeMode::Dark,
-        bold_is_bright: false,
+        bold_as_bright: false,
       },
       appearance: AppearanceConfig {
         themes_path: None,

--- a/crates/config/src/profiles.rs
+++ b/crates/config/src/profiles.rs
@@ -184,6 +184,7 @@ mod tests {
         theme: "one".into(),
         theme_mode: ThemeMode::Dark,
         bold_as_bright: false,
+        minimum_contrast: 45.0,
       },
       appearance: AppearanceConfig {
         themes_path: None,

--- a/crates/kazeterm/src/components/main_window.rs
+++ b/crates/kazeterm/src/components/main_window.rs
@@ -125,7 +125,7 @@ impl MainWindow {
 
     // Try to restore previous workspace
     let config = cx.global::<::config::Config>();
-    if config.restore_workspace {
+    if config.window.restore_workspace {
       if let Some(state) = WorkspaceState::load() {
         main_window.restore_workspace(state, window, cx);
         WorkspaceState::delete();

--- a/crates/kazeterm/src/components/main_window_render.rs
+++ b/crates/kazeterm/src/components/main_window_render.rs
@@ -33,7 +33,7 @@ impl Render for MainWindow {
     let search_visible = self.search_visible;
     let search_bar = self.search_bar.clone();
     let config = cx.global::<::config::Config>();
-    let vertical_tabs = config.vertical_tabs;
+    let vertical_tabs = config.tab.vertical;
     let tab_bar_visible = self.tab_bar_visible;
     let setting_store = cx.global::<SettingsStore>();
     let local_profiles = config.get_local_profiles_with_shells();
@@ -139,7 +139,7 @@ impl Render for MainWindow {
           &keybindings.new_tab_profile_8,
           &keybindings.new_tab_profile_9,
         ];
-        let tab_switcher_popup = cx.global::<config::Config>().tab_switcher_popup;
+        let tab_switcher_popup = cx.global::<config::Config>().tab.switcher_popup;
 
         if keybindings
           .next_tab

--- a/crates/kazeterm/src/components/main_window_search.rs
+++ b/crates/kazeterm/src/components/main_window_search.rs
@@ -17,7 +17,7 @@ impl MainWindow {
   pub(crate) fn toggle_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
     self.search_visible = !self.search_visible;
     if self.search_visible {
-      let font_size = cx.global::<::config::Config>().font_size;
+      let font_size = cx.global::<::config::Config>().font.size;
       if let Some(terminal) = self.active_terminal() {
         self.search_bar.update(cx, |search_bar, _cx| {
           search_bar.set_terminal_view(terminal);

--- a/crates/kazeterm/src/components/main_window_tab_management.rs
+++ b/crates/kazeterm/src/components/main_window_tab_management.rs
@@ -295,7 +295,7 @@ impl MainWindow {
       // If no tabs left, either close the window or insert a new tab
       if self.items.is_empty() {
         let config = cx.global::<::config::Config>();
-        if config.close_on_last_tab {
+        if config.tab.close_on_last {
           window.remove_window();
         } else {
           self.insert_new_tab(window, cx);
@@ -413,14 +413,17 @@ pub(crate) fn get_working_directory_pathbuf(working_directory: Option<String>) -
 
 #[cfg(test)]
 mod tests {
-  use config::{Config, Profile};
+  use config::{Config, Profile, TerminalConfig};
 
   use super::resolve_tab_launch;
 
   #[test]
   fn resolve_profile_launch_uses_default_profile_args() {
     let config = Config {
-      default_profile: Some("login-shell".to_string()),
+      terminal: TerminalConfig {
+        default_profile: Some("login-shell".to_string()),
+        ..TerminalConfig::default()
+      },
       profiles: vec![Profile {
         name: "login-shell".to_string(),
         shell: "bash".to_string(),

--- a/crates/kazeterm/src/components/notifications.rs
+++ b/crates/kazeterm/src/components/notifications.rs
@@ -16,7 +16,7 @@ impl MainWindow {
     reason: NotificationReason,
     cx: &mut Context<Self>,
   ) {
-    let threshold_secs = cx.global::<config::Config>().long_running_threshold_secs;
+    let threshold_secs = cx.global::<config::Config>().notification.long_running_threshold_secs;
     let idle_duration = terminal_view
       .read(cx)
       .terminal()
@@ -24,7 +24,7 @@ impl MainWindow {
       .last_input_time
       .elapsed();
 
-    let interval_secs = cx.global::<config::Config>().notification_interval_secs;
+    let interval_secs = cx.global::<config::Config>().notification.interval_secs;
     let interval_ok = match self.last_notification_time {
       Some(last) => last.elapsed() >= std::time::Duration::from_secs(interval_secs),
       None => true,

--- a/crates/kazeterm/src/components/split_pane.rs
+++ b/crates/kazeterm/src/components/split_pane.rs
@@ -291,7 +291,7 @@ impl SplitPane {
       SplitPane::Terminal { id, terminal } => {
         let right_click_context_menu = cx
           .try_global::<config::Config>()
-          .map(|c| c.right_click_context_menu)
+          .map(|c| c.terminal.right_click_context_menu)
           .unwrap_or(false);
 
         let is_active = active_pane_id.is_some_and(|active| active == *id);
@@ -355,7 +355,7 @@ impl SplitPane {
         let direction = *direction;
         let divider_width = cx
           .try_global::<config::Config>()
-          .map(|config| config.get_split_pane_divider_width())
+          .map(|config| config.pane.get_divider_width())
           .unwrap_or(6.0);
         let colors = cx.global::<SettingsStore>().theme().colors().clone();
 

--- a/crates/kazeterm/src/components/terminal_window.rs
+++ b/crates/kazeterm/src/components/terminal_window.rs
@@ -13,14 +13,14 @@ use terminal::{PtyProcessInfo, TerminalBounds, TerminalEventListener, TerminalVi
 use crate::components::MainWindow;
 
 fn parse_cursor_style(config: &config::Config) -> AlacCursorStyle {
-  let shape = match config.cursor_shape.as_str() {
+  let shape = match config.cursor.shape.as_str() {
     "underline" => CursorShape::Underline,
     "beam" => CursorShape::Beam,
     _ => CursorShape::Block,
   };
   AlacCursorStyle {
     shape,
-    blinking: config.cursor_blink,
+    blinking: config.cursor.blink,
   }
 }
 
@@ -57,7 +57,7 @@ fn new_terminal(
   env.insert("COLORTERM".to_string(), "truecolor".to_string());
 
   // Merge user-specified env vars (these can override defaults above)
-  for (key, value) in &app_config.env {
+  for (key, value) in &app_config.terminal.env {
     env.insert(key.clone(), value.clone());
   }
 
@@ -133,9 +133,9 @@ fn new_terminal(
 
   let term = Term::new(
     Config {
-      scrolling_history: app_config.get_scrollback_lines(),
+      scrolling_history: app_config.terminal.get_scrollback_lines(),
       default_cursor_style: parse_cursor_style(app_config),
-      osc52: parse_osc52(&app_config.osc52),
+      osc52: parse_osc52(&app_config.terminal.osc52),
       ..Config::default()
     },
     &TerminalBounds::default(),
@@ -260,6 +260,7 @@ pub fn new_terminal_window_with_shell(
   // Use global working_directory as fallback if no per-profile working directory
   let working_directory = working_directory.or_else(|| {
     app_config
+      .terminal
       .working_directory
       .as_ref()
       .map(|wd| PathBuf::from(wd))

--- a/crates/kazeterm/src/config.rs
+++ b/crates/kazeterm/src/config.rs
@@ -15,17 +15,17 @@ pub fn create_settings_store(config: &Config, system_is_dark: bool) -> themeing:
   use std::sync::Arc;
 
   // Determine if we should use dark mode
-  let is_system = matches!(config.theme_mode, ThemeMode::System);
-  let is_dark = match config.theme_mode {
+  let is_system = matches!(config.appearance.theme_mode, ThemeMode::System);
+  let is_dark = match config.appearance.theme_mode {
     ThemeMode::Light => false,
     ThemeMode::Dark => true,
     ThemeMode::System => system_is_dark,
   };
 
   // Load theme from assets by name
-  let (theme_name, mut palette) = config::load_theme(&config.theme, is_dark);
+  let (theme_name, mut palette) = config::load_theme(&config.appearance.theme, is_dark);
 
-  let opacity = config.get_background_opacity();
+  let opacity = config.appearance.get_background_opacity();
   if opacity < 1.0 {
     palette.border = apply_background_opacity(palette.border, opacity);
     palette.border_variant = apply_background_opacity(palette.border_variant, opacity);
@@ -61,7 +61,7 @@ pub fn create_settings_store(config: &Config, system_is_dark: bool) -> themeing:
 
   themeing::SettingsStore {
     active_theme: Arc::new(themeing::Theme {
-      id: config.theme.clone(),
+      id: config.appearance.theme.clone(),
       name: SharedString::from(theme_name),
       styles: themeing::ThemeStyles { colors: palette },
     }),

--- a/crates/kazeterm/src/config.rs
+++ b/crates/kazeterm/src/config.rs
@@ -15,15 +15,15 @@ pub fn create_settings_store(config: &Config, system_is_dark: bool) -> themeing:
   use std::sync::Arc;
 
   // Determine if we should use dark mode
-  let is_system = matches!(config.appearance.theme_mode, ThemeMode::System);
-  let is_dark = match config.appearance.theme_mode {
+  let is_system = matches!(config.colors.theme_mode, ThemeMode::System);
+  let is_dark = match config.colors.theme_mode {
     ThemeMode::Light => false,
     ThemeMode::Dark => true,
     ThemeMode::System => system_is_dark,
   };
 
   // Load theme from assets by name
-  let (theme_name, mut palette) = config::load_theme(&config.appearance.theme, is_dark);
+  let (theme_name, mut palette) = config::load_theme(&config.colors.theme, is_dark);
 
   let opacity = config.appearance.get_background_opacity();
   if opacity < 1.0 {
@@ -61,7 +61,7 @@ pub fn create_settings_store(config: &Config, system_is_dark: bool) -> themeing:
 
   themeing::SettingsStore {
     active_theme: Arc::new(themeing::Theme {
-      id: config.appearance.theme.clone(),
+      id: config.colors.theme.clone(),
       name: SharedString::from(theme_name),
       styles: themeing::ThemeStyles { colors: palette },
     }),

--- a/crates/kazeterm/src/config_watcher.rs
+++ b/crates/kazeterm/src/config_watcher.rs
@@ -282,10 +282,10 @@ fn reload_config_and_theme(cx: &mut App, change_type: FileChangeType) {
     FileChangeType::Config => {
       // Reload the entire config (which includes theme settings)
       let new_config = Config::load();
-      tracing::info!("Reloaded config: theme={}", new_config.theme);
+      tracing::info!("Reloaded config: theme={}", new_config.appearance.theme);
 
       // Update the themes path if it changed
-      if let Some(themes_path) = &new_config.themes_path {
+      if let Some(themes_path) = &new_config.appearance.themes_path {
         let path = PathBuf::from(themes_path);
         if path.exists() && path.is_dir() {
           ::config::set_custom_themes_path(path);
@@ -327,7 +327,7 @@ fn reload_config_and_theme(cx: &mut App, change_type: FileChangeType) {
       // Re-initialize gpui-component theme
       themeing::SettingsStore::init_gpui_component_theme(cx);
 
-      tracing::info!("Theme reloaded successfully: {}", config.theme);
+      tracing::info!("Theme reloaded successfully: {}", config.appearance.theme);
     }
   }
 }
@@ -361,9 +361,9 @@ pub fn watch_additional_path(path: PathBuf) {
 /// `background_blur` is enabled) so the desktop behind it is visible.
 /// When fully opaque, the window is set back to opaque mode.
 fn update_window_background_appearance(cx: &mut App, config: &Config) {
-  let opacity = config.get_background_opacity();
+  let opacity = config.appearance.get_background_opacity();
   let appearance = if opacity < 1.0 {
-    if config.background_blur {
+    if config.appearance.background_blur {
       WindowBackgroundAppearance::Blurred
     } else {
       WindowBackgroundAppearance::Transparent

--- a/crates/kazeterm/src/config_watcher.rs
+++ b/crates/kazeterm/src/config_watcher.rs
@@ -282,7 +282,7 @@ fn reload_config_and_theme(cx: &mut App, change_type: FileChangeType) {
     FileChangeType::Config => {
       // Reload the entire config (which includes theme settings)
       let new_config = Config::load();
-      tracing::info!("Reloaded config: theme={}", new_config.appearance.theme);
+      tracing::info!("Reloaded config: theme={}", new_config.colors.theme);
 
       // Update the themes path if it changed
       if let Some(themes_path) = &new_config.appearance.themes_path {
@@ -327,7 +327,7 @@ fn reload_config_and_theme(cx: &mut App, change_type: FileChangeType) {
       // Re-initialize gpui-component theme
       themeing::SettingsStore::init_gpui_component_theme(cx);
 
-      tracing::info!("Theme reloaded successfully: {}", config.appearance.theme);
+      tracing::info!("Theme reloaded successfully: {}", config.colors.theme);
     }
   }
 }

--- a/crates/kazeterm/src/main.rs
+++ b/crates/kazeterm/src/main.rs
@@ -80,7 +80,7 @@ fn init_theme_system(config: &Config) {
   ::config::register_embedded_theme_lister(crate::assets::embedded_theme_lister);
 
   // Set custom themes path if configured
-  if let Some(ref themes_path) = config.themes_path {
+  if let Some(ref themes_path) = config.appearance.themes_path {
     let path = PathBuf::from(themes_path);
     if path.exists() && path.is_dir() {
       tracing::info!("Using custom themes path: {}", path.display());
@@ -170,11 +170,11 @@ fn detect_system_dark_mode() -> bool {
 /// Open a new Kazeterm window using the current global config.
 fn open_kazeterm_window(event_source_config: EventSourceConfig, cx: &mut App) {
   let config = cx.global::<Config>().clone();
-  let window_width = config.window_width;
-  let window_height = config.window_height;
-  let start_maximized = config.start_maximized;
-  let background_opacity = config.get_background_opacity();
-  let background_blur = config.background_blur;
+  let window_width = config.window.width;
+  let window_height = config.window.height;
+  let start_maximized = config.window.start_maximized;
+  let background_opacity = config.appearance.get_background_opacity();
+  let background_blur = config.appearance.background_blur;
 
   cx.spawn(async move |cx| {
     let window_background = if background_opacity < 1.0 {

--- a/crates/terminal/src/terminal/mouse_scroll.rs
+++ b/crates/terminal/src/terminal/mouse_scroll.rs
@@ -205,7 +205,7 @@ impl Terminal {
     // copy_on_select: auto-copy selection to clipboard when mouse is released
     if cx
       .try_global::<config::Config>()
-      .is_some_and(|c| c.copy_on_select)
+      .is_some_and(|c| c.terminal.copy_on_select)
     {
       self
         .events

--- a/crates/terminal/src/terminal_element/element_impl.rs
+++ b/crates/terminal/src/terminal_element/element_impl.rs
@@ -90,7 +90,7 @@ impl Element for TerminalElement {
         let font_weight = FontWeight::NORMAL;
         let font_features = FontFeatures::default();
 
-        let minimum_contrast = 45.0;
+        let minimum_contrast = config.terminal.minimum_contrast.max(0.0);
 
         let theme = cx.theme().clone();
 

--- a/crates/terminal/src/terminal_element/element_impl.rs
+++ b/crates/terminal/src/terminal_element/element_impl.rs
@@ -90,7 +90,7 @@ impl Element for TerminalElement {
         let font_weight = FontWeight::NORMAL;
         let font_features = FontFeatures::default();
 
-        let minimum_contrast = config.terminal.minimum_contrast.max(0.0);
+        let minimum_contrast = config.colors.minimum_contrast.max(0.0);
 
         let theme = cx.theme().clone();
 

--- a/crates/terminal/src/terminal_element/element_impl.rs
+++ b/crates/terminal/src/terminal_element/element_impl.rs
@@ -81,7 +81,7 @@ impl Element for TerminalElement {
         let config = cx.global::<::config::Config>();
         let zoom_state = cx.global::<themeing::ZoomState>();
         let minimap_enabled = config.terminal.minimap_enabled;
-        let bold_is_bright = config.colors.bold_is_bright;
+        let bold_as_bright = config.colors.bold_as_bright;
 
         let font_family = gpui::SharedString::from(config.font.family.clone());
         let line_height_multiplier = 1.18_f32;
@@ -217,7 +217,7 @@ impl Element for TerminalElement {
             .as_ref()
             .map(|last_hovered_word| (link_style, &last_hovered_word.word_match)),
           minimum_contrast,
-          bold_is_bright,
+          bold_as_bright,
           cx,
         );
 

--- a/crates/terminal/src/terminal_element/element_impl.rs
+++ b/crates/terminal/src/terminal_element/element_impl.rs
@@ -67,7 +67,7 @@ impl Element for TerminalElement {
     let inactive = self.inactive;
     let inactive_opacity = cx
       .try_global::<::config::Config>()
-      .map(|c| c.get_inactive_pane_opacity())
+      .map(|c| c.pane.get_inactive_opacity())
       .unwrap_or(0.6);
     self.interactivity.prepaint(
       global_id,
@@ -80,11 +80,11 @@ impl Element for TerminalElement {
         let hitbox = hitbox.unwrap();
         let config = cx.global::<::config::Config>();
         let zoom_state = cx.global::<themeing::ZoomState>();
-        let minimap_enabled = config.minimap_enabled;
+        let minimap_enabled = config.terminal.minimap_enabled;
 
-        let font_family = gpui::SharedString::from(config.font_family.clone());
+        let font_family = gpui::SharedString::from(config.font.family.clone());
         let line_height_multiplier = 1.18_f32;
-        let effective_font_size = zoom_state.effective_font_size(config.font_size);
+        let effective_font_size = zoom_state.effective_font_size(config.font.size);
         let font_size = AbsoluteLength::from(Pixels::from(effective_font_size));
         let font_weight = FontWeight::NORMAL;
         let font_features = FontFeatures::default();
@@ -370,7 +370,7 @@ impl Element for TerminalElement {
 
       let right_click_context_menu = cx
         .try_global::<config::Config>()
-        .map(|c| c.right_click_context_menu)
+        .map(|c| c.terminal.right_click_context_menu)
         .unwrap_or(false);
 
       self.register_mouse_listeners(

--- a/crates/terminal/src/terminal_element/element_impl.rs
+++ b/crates/terminal/src/terminal_element/element_impl.rs
@@ -81,6 +81,7 @@ impl Element for TerminalElement {
         let config = cx.global::<::config::Config>();
         let zoom_state = cx.global::<themeing::ZoomState>();
         let minimap_enabled = config.terminal.minimap_enabled;
+        let bold_is_bright = config.terminal.bold_is_bright;
 
         let font_family = gpui::SharedString::from(config.font.family.clone());
         let line_height_multiplier = 1.18_f32;
@@ -216,6 +217,7 @@ impl Element for TerminalElement {
             .as_ref()
             .map(|last_hovered_word| (link_style, &last_hovered_word.word_match)),
           minimum_contrast,
+          bold_is_bright,
           cx,
         );
 

--- a/crates/terminal/src/terminal_element/element_impl.rs
+++ b/crates/terminal/src/terminal_element/element_impl.rs
@@ -81,7 +81,7 @@ impl Element for TerminalElement {
         let config = cx.global::<::config::Config>();
         let zoom_state = cx.global::<themeing::ZoomState>();
         let minimap_enabled = config.terminal.minimap_enabled;
-        let bold_is_bright = config.terminal.bold_is_bright;
+        let bold_is_bright = config.colors.bold_is_bright;
 
         let font_family = gpui::SharedString::from(config.font.family.clone());
         let line_height_multiplier = 1.18_f32;

--- a/crates/terminal/src/terminal_element/grid_layout.rs
+++ b/crates/terminal/src/terminal_element/grid_layout.rs
@@ -25,6 +25,7 @@ impl TerminalElement {
     text_style: &TextStyle,
     hyperlink: Option<(HighlightStyle, &RangeInclusive<AlacPoint>)>,
     minimum_contrast: f32,
+    bold_is_bright: bool,
     cx: &App,
   ) -> (Vec<LayoutRect>, Vec<BatchedTextRun>) {
     let theme = cx.theme();
@@ -55,6 +56,15 @@ impl TerminalElement {
           .contains(alacritty_terminal::term::cell::Flags::INVERSE)
         {
           std::mem::swap(&mut fg, &mut bg);
+        }
+
+        // Bold-as-bright: promote standard named colors to their bright variant
+        if bold_is_bright
+          && cell
+            .flags
+            .intersects(alacritty_terminal::term::cell::Flags::BOLD)
+        {
+          fg = to_bright_named(fg);
         }
 
         if !matches!(bg, Color::Named(NamedColor::Background)) {
@@ -227,5 +237,24 @@ impl TerminalElement {
     }
 
     result
+  }
+}
+
+/// Promote a standard named ANSI color (0–7) to its bright variant (8–15).
+/// Non-standard named colors, indexed colors, and true colors are returned unchanged.
+fn to_bright_named(color: Color) -> Color {
+  match color {
+    Color::Named(n) => Color::Named(match n {
+      NamedColor::Black => NamedColor::BrightBlack,
+      NamedColor::Red => NamedColor::BrightRed,
+      NamedColor::Green => NamedColor::BrightGreen,
+      NamedColor::Yellow => NamedColor::BrightYellow,
+      NamedColor::Blue => NamedColor::BrightBlue,
+      NamedColor::Magenta => NamedColor::BrightMagenta,
+      NamedColor::Cyan => NamedColor::BrightCyan,
+      NamedColor::White => NamedColor::BrightWhite,
+      other => other,
+    }),
+    other => other,
   }
 }

--- a/crates/terminal/src/terminal_element/grid_layout.rs
+++ b/crates/terminal/src/terminal_element/grid_layout.rs
@@ -25,7 +25,7 @@ impl TerminalElement {
     text_style: &TextStyle,
     hyperlink: Option<(HighlightStyle, &RangeInclusive<AlacPoint>)>,
     minimum_contrast: f32,
-    bold_is_bright: bool,
+    bold_as_bright: bool,
     cx: &App,
   ) -> (Vec<LayoutRect>, Vec<BatchedTextRun>) {
     let theme = cx.theme();
@@ -59,7 +59,7 @@ impl TerminalElement {
         }
 
         // Bold-as-bright: promote standard named colors to their bright variant
-        if bold_is_bright
+        if bold_as_bright
           && cell
             .flags
             .intersects(alacritty_terminal::term::cell::Flags::BOLD)

--- a/crates/terminal/src/terminal_view.rs
+++ b/crates/terminal/src/terminal_view.rs
@@ -35,20 +35,20 @@ const DEFAULT_TAB_TITLE_CHANGE_DELAY: Duration = Duration::from_millis(200);
 /// Returns the cursor blink interval from config, or the default constant.
 fn cursor_blink_interval(cx: &gpui::App) -> Duration {
   cx.try_global::<config::Config>()
-    .map(|c| c.get_cursor_blink_interval())
+    .map(|c| c.cursor.get_blink_interval())
     .unwrap_or(CURSOR_BLINK_INTERVAL)
 }
 
 fn tab_title_change_delay(cx: &gpui::App) -> Duration {
   cx.try_global::<config::Config>()
-    .map(|c| c.get_tab_title_change_delay())
+    .map(|c| c.tab.get_title_change_delay())
     .unwrap_or(DEFAULT_TAB_TITLE_CHANGE_DELAY)
 }
 
 /// Returns whether cursor blinking is enabled from config.
 fn cursor_blink_enabled(cx: &gpui::App) -> bool {
   cx.try_global::<config::Config>()
-    .map(|c| c.cursor_blink)
+    .map(|c| c.cursor.blink)
     .unwrap_or(true)
 }
 

--- a/crates/themeing/src/lib.rs
+++ b/crates/themeing/src/lib.rs
@@ -295,10 +295,10 @@ impl SettingsStore {
       theme.selection = colors.element_selection_background;
 
       let config = app.global::<config::Config>();
-      theme.font_family = config.ui_font_family.clone().into();
-      theme.font_size = gpui::px(config.ui_font_size);
-      theme.mono_font_family = config.font_family.clone().into();
-      theme.mono_font_size = gpui::px(config.font_size);
+      theme.font_family = config.font.ui_family.clone().into();
+      theme.font_size = gpui::px(config.font.ui_size);
+      theme.mono_font_family = config.font.family.clone().into();
+      theme.mono_font_size = gpui::px(config.font.size);
     });
   }
 }


### PR DESCRIPTION
This pull request introduces a significant refactor to the configuration structure, migrating from a flat config format to a more organized, nested table structure. It also updates migration logic to handle these changes and ensures all usage and tests are compatible with the new structure.

**Config structure refactor and migration:**

* Introduced two new config migrations:
  - The first migration (`migrate_v20260412_3_to_20260414_1`) restructures the flat config fields into nested TOML tables such as `[appearance]`, `[font]`, `[window]`, `[tab]`, `[pane]`, `[terminal]`, `[cursor]`, and `[notification]`.
  - The second migration (`migrate_v20260414_1_to_20260414_2`) moves `theme` and `theme_mode` from `[appearance]` to `[colors]`, and `bold_as_bright`/`minimum_contrast` from `[terminal]` to `[colors]`.
* Updated the `CURRENT_CONFIG_VERSION` to `20260414.2` and registered the new migrations in the migration chain. [[1]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L4-R4) [[2]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718R98-R107)

**Codebase and test updates for nested config:**

* Refactored all config field accesses in the codebase (e.g., `config.font_family` to `config.font.family`, `config.theme` to `config.colors.theme`, etc.) to match the new nested structure. [[1]](diffhunk://#diff-bcda6355edeb2e6a5541a1f8dbe0bacd5e5f7f06036ffbaaa8316825d1a5e569L218-R224) [[2]](diffhunk://#diff-bcda6355edeb2e6a5541a1f8dbe0bacd5e5f7f06036ffbaaa8316825d1a5e569L235-R259) [[3]](diffhunk://#diff-569b68312b7e78fae747e1d1a2de103005ad9224ae72f0432dc84529a1d3afe7L82-R82)
* Updated test cases and helper functions to work with the nested structure, including a new `get_nested` helper for accessing values in nested tables in migration tests. [[1]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718R572-R576) [[2]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L434-R590) [[3]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L449-R603) [[4]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L482-R636) [[5]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L509-R682) [[6]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L571-R722) [[7]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L594-R745) [[8]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L621-R771) [[9]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L661-R810) [[10]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L685-R834) [[11]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L700-R852) [[12]](diffhunk://#diff-1068bdd3a051b3fd59a61a76c020b684ed29d7235db8d22f3a3c0e5dc28df718L726-R874) [[13]](diffhunk://#diff-bcda6355edeb2e6a5541a1f8dbe0bacd5e5f7f06036ffbaaa8316825d1a5e569L541-R544) [[14]](diffhunk://#diff-bcda6355edeb2e6a5541a1f8dbe0bacd5e5f7f06036ffbaaa8316825d1a5e569L688-R695)
* Updated the construction of `Config` objects in tests to use the new nested struct fields and default initializations. [[1]](diffhunk://#diff-569b68312b7e78fae747e1d1a2de103005ad9224ae72f0432dc84529a1d3afe7L157-R161) [[2]](diffhunk://#diff-569b68312b7e78fae747e1d1a2de103005ad9224ae72f0432dc84529a1d3afe7R183-R219)

These changes make the config more maintainable, extensible, and easier to reason about by grouping related settings into logical sections.