### PR TITLE
fix: stop keybinding keystrokes leaking into terminal and ensure app fully quits on macOS

### DIFF
--- a/crates/config/src/keybinding.rs
+++ b/crates/config/src/keybinding.rs
@@ -189,8 +189,8 @@ impl Default for KeybindingConfig {
         zoom_in: KeybindingList::new("cmd-="),
         zoom_out: KeybindingList::new("cmd--"),
         zoom_reset: KeybindingList::new("cmd-0"),
-        next_tab: KeybindingList::new("ctrl-tab"),
-        previous_tab: KeybindingList::new("ctrl-shift-tab"),
+        next_tab: KeybindingList::from_vec(vec!["ctrl-tab".into(), "cmd-shift-]".into()]),
+        previous_tab: KeybindingList::from_vec(vec!["ctrl-shift-tab".into(), "cmd-shift-[".into()]),
         select_tab_1: KeybindingList::new("cmd-1"),
         select_tab_2: KeybindingList::new("cmd-2"),
         select_tab_3: KeybindingList::new("cmd-3"),
@@ -200,18 +200,18 @@ impl Default for KeybindingConfig {
         select_tab_7: KeybindingList::new("cmd-7"),
         select_tab_8: KeybindingList::new("cmd-8"),
         select_tab_9: KeybindingList::new("cmd-9"),
-        toggle_search: KeybindingList::new("ctrl-shift-f"),
-        split_horizontal: KeybindingList::new("ctrl-shift-d"),
-        split_vertical: KeybindingList::new("ctrl-shift-e"),
-        close_pane: KeybindingList::new("ctrl-shift-w"),
-        focus_next_pane: KeybindingList::new("ctrl-shift-]"),
-        focus_previous_pane: KeybindingList::new("ctrl-shift-["),
-        focus_pane_up: KeybindingList::new("cmd-alt-up"),
-        focus_pane_down: KeybindingList::new("cmd-alt-down"),
-        focus_pane_left: KeybindingList::new("cmd-alt-left"),
-        focus_pane_right: KeybindingList::new("cmd-alt-right"),
+        toggle_search: KeybindingList::new("cmd-f"),
+        split_horizontal: KeybindingList::new("alt-shift-minus"),
+        split_vertical: KeybindingList::new("alt-shift-equal"),
+        close_pane: KeybindingList::new("cmd-w"),
+        focus_next_pane: KeybindingList::new("cmd-]"),
+        focus_previous_pane: KeybindingList::new("cmd-["),
+        focus_pane_up: KeybindingList::new("alt-up"),
+        focus_pane_down: KeybindingList::new("alt-down"),
+        focus_pane_left: KeybindingList::new("alt-left"),
+        focus_pane_right: KeybindingList::new("alt-right"),
         swap_split_panes: KeybindingList::new("ctrl-shift-x"),
-        toggle_fullscreen: KeybindingList::new("f12"),
+        toggle_fullscreen: KeybindingList::new("cmd-ctr-f"),
         toggle_tab_bar: KeybindingList::new("ctrl-shift-b"),
         new_tab: KeybindingList::new("cmd-t"),
         new_tab_profile_1: KeybindingList::new("ctrl-shift-1"),
@@ -245,15 +245,15 @@ impl Default for KeybindingConfig {
         select_tab_8: KeybindingList::new("ctrl-alt-8"),
         select_tab_9: KeybindingList::new("ctrl-alt-9"),
         toggle_search: KeybindingList::new("ctrl-shift-f"),
-        split_horizontal: KeybindingList::new("ctrl-shift-d"),
-        split_vertical: KeybindingList::new("ctrl-shift-e"),
+        split_horizontal: KeybindingList::new("alt-shift-minus"),
+        split_vertical: KeybindingList::new("alt-shift-equal"),
         close_pane: KeybindingList::new("ctrl-shift-w"),
         focus_next_pane: KeybindingList::new("ctrl-shift-]"),
         focus_previous_pane: KeybindingList::new("ctrl-shift-["),
-        focus_pane_up: KeybindingList::new("ctrl-alt-up"),
-        focus_pane_down: KeybindingList::new("ctrl-alt-down"),
-        focus_pane_left: KeybindingList::new("ctrl-alt-left"),
-        focus_pane_right: KeybindingList::new("ctrl-alt-right"),
+        focus_pane_up: KeybindingList::new("alt-up"),
+        focus_pane_down: KeybindingList::new("alt-down"),
+        focus_pane_left: KeybindingList::new("alt-left"),
+        focus_pane_right: KeybindingList::new("alt-right"),
         swap_split_panes: KeybindingList::new("ctrl-shift-x"),
         toggle_fullscreen: KeybindingList::new("f11"),
         toggle_tab_bar: KeybindingList::new("ctrl-shift-b"),
@@ -502,11 +502,7 @@ mod tests {
   }
 
   fn expected_default_directional_pane_binding(direction: &str) -> String {
-    if cfg!(target_os = "macos") {
-      format!("cmd-alt-{}", direction)
-    } else {
-      format!("ctrl-alt-{}", direction)
-    }
+    format!("alt-{}", direction)
   }
 
   fn expected_platform_modifier_label() -> &'static str {
@@ -705,18 +701,10 @@ mod tests {
     }
 
     let focus_pane_up = ParsedKeybinding::parse(config.focus_pane_up.first().unwrap());
-    if cfg!(target_os = "macos") {
-      assert!(focus_pane_up.matches(false, false, true, true, "up"));
-    } else {
-      assert!(focus_pane_up.matches(true, false, true, false, "up"));
-    }
+    assert!(focus_pane_up.matches(false, false, true, false, "up"));
 
     let focus_pane_right = ParsedKeybinding::parse(config.focus_pane_right.first().unwrap());
-    if cfg!(target_os = "macos") {
-      assert!(focus_pane_right.matches(false, false, true, true, "right"));
-    } else {
-      assert!(focus_pane_right.matches(true, false, true, false, "right"));
-    }
+    assert!(focus_pane_right.matches(false, false, true, false, "right"));
   }
 
   #[test]
@@ -758,7 +746,11 @@ mod tests {
     assert_eq!(config.copy, "ctrl-c");
     // Non-specified fields use defaults
     assert_eq!(config.paste, expected_default_paste_binding());
-    assert_eq!(config.next_tab, "ctrl-tab");
+    if cfg!(target_os = "macos") {
+        assert_eq!(config.next_tab, KeybindingList::from_vec(vec!["ctrl-tab".into(), "cmd-shift-]".into()]));
+    } else {
+        assert_eq!(config.next_tab, "ctrl-tab");
+    }
   }
 
   #[test]

--- a/crates/kazeterm/src/components/main_window_dialog_handlers.rs
+++ b/crates/kazeterm/src/components/main_window_dialog_handlers.rs
@@ -89,16 +89,18 @@ impl MainWindow {
         // Save workspace state before closing
         let state = self.capture_workspace_state(cx);
         state.save();
-        // User confirmed, close the window
+        // User confirmed, close the window and quit the app
         self.close_confirm_dialog = None;
         self._close_confirm_subscription = None;
         window.remove_window();
+        cx.quit();
       }
       CloseConfirmEvent::Close => {
         // Close without saving workspace state
         self.close_confirm_dialog = None;
         self._close_confirm_subscription = None;
         window.remove_window();
+        cx.quit();
       }
       CloseConfirmEvent::Cancel => {
         // User cancelled, just close the dialog

--- a/crates/kazeterm/src/components/main_window_render.rs
+++ b/crates/kazeterm/src/components/main_window_render.rs
@@ -741,7 +741,7 @@ impl Render for MainWindow {
         ];
         let tab_switcher_popup = cx.global::<config::Config>().tab.switcher_popup;
 
-        if keybindings
+        let matched = if keybindings
           .next_tab
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
@@ -752,6 +752,7 @@ impl Render for MainWindow {
             let next_ix = (current_ix + 1) % this.items.len();
             this.set_active_tab(next_ix, window, cx);
           }
+          true
         } else if keybindings
           .previous_tab
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
@@ -767,97 +768,121 @@ impl Render for MainWindow {
             };
             this.set_active_tab(prev_ix, window, cx);
           }
+          true
         } else if keybindings
           .toggle_search
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
           || (e.keystroke.key == "Escape" && this.search_visible)
         {
           this.toggle_search(window, cx);
+          true
         } else if keybindings
           .split_horizontal
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.split_pane_horizontal(window, cx);
+          true
         } else if keybindings
           .split_vertical
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.split_pane_vertical(window, cx);
+          true
         } else if keybindings
           .close_pane
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.close_active_pane(window, cx);
+          true
         } else if keybindings
           .focus_next_pane
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.focus_next_pane(window, cx);
+          true
         } else if keybindings
           .focus_previous_pane
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.focus_prev_pane(window, cx);
+          true
         } else if keybindings
           .focus_pane_up
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.focus_pane_up(window, cx);
+          true
         } else if keybindings
           .focus_pane_down
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.focus_pane_down(window, cx);
+          true
         } else if keybindings
           .focus_pane_left
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.focus_pane_left(window, cx);
+          true
         } else if keybindings
           .focus_pane_right
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.focus_pane_right(window, cx);
+          true
         } else if keybindings
           .swap_split_panes
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.swap_split_panes(window, cx);
+          true
         } else if keybindings
           .toggle_fullscreen
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           window.toggle_fullscreen();
+          true
         } else if keybindings
           .toggle_tab_bar
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.toggle_tab_bar(cx);
+          true
         } else if keybindings
           .new_tab
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.insert_new_tab(window, cx);
+          true
         } else if let Some((i, _)) = kb_select_tabs.iter().enumerate().find(|(_, kb_select_tab)| {
           kb_select_tab.matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         }) {
           this.select_tab_by_shortcut(i + 1, window, cx);
+          true
         } else if keybindings
           .quit
           .matches(mods.control, mods.shift, mods.alt, mods.platform, key)
         {
           this.show_close_confirm_dialog(window, cx);
+          true
         } else {
           // Check profile-specific new tab shortcuts.
           let profiles = cx.global::<config::Config>().get_local_profile_names();
+          let mut found = false;
           for (i, kb_profile) in kb_new_tab_profiles.iter().enumerate() {
             if kb_profile.matches(mods.control, mods.shift, mods.alt, mods.platform, key) {
               if let Some(profile_name) = profiles.get(i) {
                 this.insert_new_tab_with_profile(Some(profile_name), None, window, cx);
               }
+              found = true;
               break;
             }
           }
+          found
+        };
+
+        if matched {
+          cx.stop_propagation();
         }
       }))
       .on_key_up(cx.listener(move |this, e: &KeyUpEvent, _window, cx| {

--- a/crates/kazeterm/src/components/main_window_tab_management.rs
+++ b/crates/kazeterm/src/components/main_window_tab_management.rs
@@ -309,6 +309,7 @@ impl MainWindow {
         let config = cx.global::<::config::Config>();
         if config.tab.close_on_last {
           window.remove_window();
+          cx.quit();
         } else {
           self.insert_new_tab(window, cx);
         }


### PR DESCRIPTION
- Add cx.stop_propagation() when keybindings match to prevent characters from being sent to the terminal via InputHandler
- Call cx.quit() after window.remove_window() so the process exits when closing via confirm dialog or last tab shell exit
- Revise default macOS keybindings to follow platform conventions